### PR TITLE
fix: .env파일 전역상수로 구현

### DIFF
--- a/src/api/api.ts
+++ b/src/api/api.ts
@@ -1,10 +1,9 @@
-import { getEnv } from "@utils/getEnv";
 import axios from "axios";
 
-const BASE_URL = getEnv("BASE_URL");
+declare const __BASE_URL__: string;
 
 const instance = axios.create({
-  baseURL: `${BASE_URL}/api/`,
+  baseURL: `${__BASE_URL__}/api/`,
   timeout: 1000,
   headers: { "Content-Type": "application/json" },
 });

--- a/src/components/Location/KakaoMap.tsx
+++ b/src/components/Location/KakaoMap.tsx
@@ -1,13 +1,13 @@
 import { TKakaoMapp } from "@customTypes/kakaomap";
-import { getEnv } from "@utils/getEnv";
 import { Map, MapMarker, useKakaoLoader } from "react-kakao-maps-sdk";
 import { useLocation } from "react-router-dom";
 import iksanMap from "../../assets/images/iksan_map.png";
 import locationMap from "../../assets/images/map_img.png";
 
+declare const __KAKAOMAP_APP_KEY__: string;
 const KakaoMap = ({ lat, lng, location }: TKakaoMapp) => {
   const [loading, error] = useKakaoLoader({
-    appkey: getEnv("KAKAOMAP_APP_KEY"), // 발급 받은 APPKEY, .env에서 가져옴
+    appkey: __KAKAOMAP_APP_KEY__, // 발급 받은 APPKEY, .env에서 가져옴
   });
   const { pathname } = useLocation();
 

--- a/src/utils/getEnv.ts
+++ b/src/utils/getEnv.ts
@@ -1,9 +1,0 @@
-export function getEnv(key:string) {
-    if (typeof window === 'undefined') {
-      // 서버 환경
-      return process.env[key];
-    } else {
-      // 클라이언트 환경
-      return import.meta.env[`VITE_${key}`];
-    }
-  }

--- a/vite.config.ts
+++ b/vite.config.ts
@@ -1,8 +1,16 @@
-import { defineConfig } from "vite";
 import react from "@vitejs/plugin-react-swc";
+import { defineConfig, loadEnv } from "vite";
 import tsconfigPaths from "vite-tsconfig-paths";
 
 // https://vitejs.dev/config/
-export default defineConfig({
-  plugins: [react(), tsconfigPaths()],
+export default defineConfig(({ command, mode }) => {
+  const env = loadEnv(mode, process.cwd(), "");
+
+  return {
+    plugins: [react(), tsconfigPaths()],
+    define: {
+      __BASE_URL__: JSON.stringify(env.BASE_URL),
+      __KAKAOMAP_APP_KEY__: JSON.stringify(env.KAKAOMAP_APP_KEY),
+    },
+  };
 });

--- a/vite.config.ts
+++ b/vite.config.ts
@@ -3,7 +3,7 @@ import { defineConfig, loadEnv } from "vite";
 import tsconfigPaths from "vite-tsconfig-paths";
 
 // https://vitejs.dev/config/
-export default defineConfig(({ command, mode }) => {
+export default defineConfig(({ mode }) => {
   const env = loadEnv(mode, process.cwd(), "");
 
   return {


### PR DESCRIPTION
## #️⃣ 연관된 이슈

> #52 

## 📝 작업 내용

> env파일 환경 변수 이름에서 VITE_를 제거한 후 viteconfig에서 전역 상수로 바꿔서 구현했습니다.

### 스크린샷 (선택)

## 💬 리뷰 요구사항(선택)
