### PR TITLE
game/순위기록/팀순위 레이아웃

### DIFF
--- a/src/components/TeamRanking/RankingChart.tsx
+++ b/src/components/TeamRanking/RankingChart.tsx
@@ -1,0 +1,11 @@
+import ArticleTitle from "@components/common/ArticleTitle";
+import { StyledArticle } from "@styles/Ranking.style";
+
+const RankingChart = () => {
+  return (
+    <StyledArticle>
+      <ArticleTitle title="2024 시즌 팀 순위" />
+    </StyledArticle>
+  );
+};
+export default RankingChart;

--- a/src/components/TeamRanking/RecordBatter.tsx
+++ b/src/components/TeamRanking/RecordBatter.tsx
@@ -1,11 +1,11 @@
 import ArticleTitle from "@components/common/ArticleTitle";
 import { StyledArticle } from "@styles/Ranking.style";
 
-const RecordCatcher = () => {
+const RecordBatter = () => {
   return (
     <StyledArticle>
       <ArticleTitle title="2024 시즌 팀 타자 기록" />
     </StyledArticle>
   );
 };
-export default RecordCatcher;
+export default RecordBatter;

--- a/src/components/TeamRanking/RecordCatcher.tsx
+++ b/src/components/TeamRanking/RecordCatcher.tsx
@@ -1,0 +1,11 @@
+import ArticleTitle from "@components/common/ArticleTitle";
+import { StyledArticle } from "@styles/Ranking.style";
+
+const RecordCatcher = () => {
+  return (
+    <StyledArticle>
+      <ArticleTitle title="2024 시즌 팀 타자 기록" />
+    </StyledArticle>
+  );
+};
+export default RecordCatcher;

--- a/src/components/TeamRanking/RecordPicher.tsx
+++ b/src/components/TeamRanking/RecordPicher.tsx
@@ -1,0 +1,11 @@
+import ArticleTitle from "@components/common/ArticleTitle";
+import { StyledArticle } from "@styles/Ranking.style";
+
+const RecordPicher = () => {
+  return (
+    <StyledArticle>
+      <ArticleTitle title="2024 시즌 팀 투수 기록" />
+    </StyledArticle>
+  );
+};
+export default RecordPicher;

--- a/src/components/TeamRanking/RecordTeam.tsx
+++ b/src/components/TeamRanking/RecordTeam.tsx
@@ -1,0 +1,11 @@
+import ArticleTitle from "@components/common/ArticleTitle";
+import { StyledArticle } from "@styles/Ranking.style";
+
+const RecordTeam = () => {
+  return (
+    <StyledArticle>
+      <ArticleTitle title="2024 시즌 팀 기록" />
+    </StyledArticle>
+  );
+};
+export default RecordTeam;

--- a/src/components/TeamRanking/WinLose.tsx
+++ b/src/components/TeamRanking/WinLose.tsx
@@ -1,0 +1,11 @@
+import ArticleTitle from "@components/common/ArticleTitle";
+import { StyledArticle } from "@styles/Ranking.style";
+
+const WinLose = () => {
+  return (
+    <StyledArticle>
+      <ArticleTitle title="2024 시즌 팀 간 승패표" />
+    </StyledArticle>
+  );
+};
+export default WinLose;

--- a/src/components/common/ArticleTitle.tsx
+++ b/src/components/common/ArticleTitle.tsx
@@ -1,0 +1,21 @@
+import styled from "styled-components";
+
+export const StyledHeader = styled.h4`
+  margin-bottom: 10px;
+  font-size: 18px;
+  &::before {
+    content: "";
+    display: inline-block;
+    width: 4px;
+    height: 20px;
+    background-color: #d23933;
+    vertical-align: middle;
+    margin-right: 13px;
+    margin-bottom: 2px;
+  }
+`;
+
+const ArticleTitle = ({ title }: { title: string }) => {
+  return <StyledHeader>{title}</StyledHeader>;
+};
+export default ArticleTitle;

--- a/src/components/common/RankingTab.tsx
+++ b/src/components/common/RankingTab.tsx
@@ -1,0 +1,54 @@
+import { NavLink } from "react-router-dom";
+import styled from "styled-components";
+
+const Tab = styled.ul`
+  width: 100%;
+  display: flex;
+  align-items: center;
+  margin-top: 38px;
+  text-align: center;
+`;
+
+const TabItem = styled.li`
+  width: 120px;
+  height: 40px;
+  box-sizing: border-box;
+  border: 1px solid #e4e4e4;
+  &:active {
+    background-color: red;
+  }
+  &:not(:first-child) {
+    border-left: none;
+  }
+`;
+
+const TabTitle = styled(NavLink)`
+  display: block;
+  font-size: 14px;
+  line-height: 38px;
+  text-align: center;
+  &.active {
+    background-color: #ec0a0b;
+    color: white;
+  }
+`;
+
+const RankingTab = () => {
+  return (
+    <Tab>
+      <TabItem>
+        <TabTitle to="">팀순위</TabTitle>
+      </TabItem>
+      <TabItem>
+        <TabTitle to="../pitcher">투수순위</TabTitle>
+      </TabItem>
+      <TabItem>
+        <TabTitle to="../batter">타자순위</TabTitle>
+      </TabItem>
+      <TabItem>
+        <TabTitle to="../crowd">관중현황</TabTitle>
+      </TabItem>
+    </Tab>
+  );
+};
+export default RankingTab;

--- a/src/pages/TeamRanking.tsx
+++ b/src/pages/TeamRanking.tsx
@@ -1,26 +1,18 @@
 import RankingChart from "@components/TeamRanking/RankingChart";
-import RecordCatcher from "@components/TeamRanking/RecordCatcher";
+import RecordBatter from "@components/TeamRanking/RecordBatter";
 import RecordPicher from "@components/TeamRanking/RecordPicher";
 import RecordTeam from "@components/TeamRanking/RecordTeam";
 import WinLose from "@components/TeamRanking/WinLose";
-import styled from "styled-components";
-
-const RankingContainer = styled.div`
-  width: 100%;
-  height: 100%;
-  display: flex;
-  flex-direction: column;
-  gap: 45px;
-  margin-top: 45px;
-`;
+import RankingTab from "@components/common/RankingTab";
 
 const TeamRanking = () => {
   return (
     <>
+      <RankingTab />
       <RankingChart />
       <RecordTeam />
       <RecordPicher />
-      <RecordCatcher />
+      <RecordBatter />
       <WinLose />
     </>
   );

--- a/src/pages/TeamRanking.tsx
+++ b/src/pages/TeamRanking.tsx
@@ -1,0 +1,28 @@
+import RankingChart from "@components/TeamRanking/RankingChart";
+import RecordCatcher from "@components/TeamRanking/RecordCatcher";
+import RecordPicher from "@components/TeamRanking/RecordPicher";
+import RecordTeam from "@components/TeamRanking/RecordTeam";
+import WinLose from "@components/TeamRanking/WinLose";
+import styled from "styled-components";
+
+const RankingContainer = styled.div`
+  width: 100%;
+  height: 100%;
+  display: flex;
+  flex-direction: column;
+  gap: 45px;
+  margin-top: 45px;
+`;
+
+const TeamRanking = () => {
+  return (
+    <>
+      <RankingChart />
+      <RecordTeam />
+      <RecordPicher />
+      <RecordCatcher />
+      <WinLose />
+    </>
+  );
+};
+export default TeamRanking;

--- a/src/router/index.tsx
+++ b/src/router/index.tsx
@@ -17,11 +17,12 @@ import Pitcher from "@pages/Pitcher";
 import PitcherDetail from "@pages/PitcherDetail";
 import Press from "@pages/Press";
 import PressDetail from "@pages/PressDetail";
+import TeamRanking from "@pages/TeamRanking";
 import WizParkGuide from "@pages/WizParkGuide.tsx";
 import WizParkIntro from "@pages/WizParkIntro.tsx";
 import BasicLayout from "layouts/BasicLayout";
 import CommonLayout from "layouts/CommonLayout";
-import { createBrowserRouter } from "react-router-dom";
+import { Navigate, createBrowserRouter } from "react-router-dom";
 
 export const router = createBrowserRouter([
   {
@@ -133,7 +134,10 @@ export const router = createBrowserRouter([
           },
           {
             path: "ranking",
-            element: "순위 component",
+            children: [
+              { index: true, element: <Navigate to="team" /> },
+              { path: "team", element: <TeamRanking /> },
+            ],
           },
           {
             path: "watchPoint",

--- a/src/styles/Ranking.style.ts
+++ b/src/styles/Ranking.style.ts
@@ -1,0 +1,8 @@
+import styled from "styled-components";
+
+export const StyledArticle = styled.article`
+  width: 100%;
+  height: 435px;
+  margin-top: 45px;
+  border: 1px solid black;
+`;


### PR DESCRIPTION
## #️⃣ 연관된 이슈

> #56 

## 📝 작업 내용

> 정규리그/순위기록/팀순위 페이지 레이아웃 마크업

### 스크린샷 (선택)
![image](https://github.com/user-attachments/assets/0af1e347-5b62-4825-9d79-0d52b300e9bd)

## 💬 리뷰 요구사항(선택)
1. 레이아웃의 위치만 표시, 각 article 내부는 라이브러리 사용 예정
2. 탭과 각article의 제목은 다른 페이지에서도 사용하기 때문에 common폴더에 생성
3. ranking탭을 누르면 team으로 이동하도록 라우터 설정 -> 이부분으로 인한 탭버튼 사라지는 현상은 리팩토링에서 수정 예정
4. 탭 버튼 누를 경우 각 페이지로 이동되도록 연결하였지만, 아직 생성되지 않은 페이지라 404에러 발생
