### PR TITLE
html문자열 파싱

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -12,6 +12,7 @@
         "@tanstack/react-table": "^8.20.5",
         "axios": "^1.7.7",
         "echarts": "^5.5.1",
+        "html-react-parser": "^5.1.16",
         "react": "^18.3.1",
         "react-dom": "^18.3.1",
         "react-icons": "^5.3.0",
@@ -2092,6 +2093,57 @@
         "node": ">=6.0.0"
       }
     },
+    "node_modules/dom-serializer": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/dom-serializer/-/dom-serializer-2.0.0.tgz",
+      "integrity": "sha512-wIkAryiqt/nV5EQKqQpo3SToSOV9J0DnbJqwK7Wv/Trc92zIAYZ4FlMu+JPFW1DfGFt81ZTCGgDEabffXeLyJg==",
+      "dependencies": {
+        "domelementtype": "^2.3.0",
+        "domhandler": "^5.0.2",
+        "entities": "^4.2.0"
+      },
+      "funding": {
+        "url": "https://github.com/cheeriojs/dom-serializer?sponsor=1"
+      }
+    },
+    "node_modules/domelementtype": {
+      "version": "2.3.0",
+      "resolved": "https://registry.npmjs.org/domelementtype/-/domelementtype-2.3.0.tgz",
+      "integrity": "sha512-OLETBj6w0OsagBwdXnPdN0cnMfF9opN69co+7ZrbfPGrdpPVNBUj02spi6B1N7wChLQiPn4CSH/zJvXw56gmHw==",
+      "funding": [
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/fb55"
+        }
+      ]
+    },
+    "node_modules/domhandler": {
+      "version": "5.0.3",
+      "resolved": "https://registry.npmjs.org/domhandler/-/domhandler-5.0.3.tgz",
+      "integrity": "sha512-cgwlv/1iFQiFnU96XXgROh8xTeetsnJiDsTc7TYCLFd9+/WNkIqPTxiM/8pSd8VIrhXGTf1Ny1q1hquVqDJB5w==",
+      "dependencies": {
+        "domelementtype": "^2.3.0"
+      },
+      "engines": {
+        "node": ">= 4"
+      },
+      "funding": {
+        "url": "https://github.com/fb55/domhandler?sponsor=1"
+      }
+    },
+    "node_modules/domutils": {
+      "version": "3.1.0",
+      "resolved": "https://registry.npmjs.org/domutils/-/domutils-3.1.0.tgz",
+      "integrity": "sha512-H78uMmQtI2AhgDJjWeQmHwJJ2bLPD3GMmO7Zja/ZZh84wkm+4ut+IUnUdRa8uCGX88DiVx1j6FRe1XfxEgjEZA==",
+      "dependencies": {
+        "dom-serializer": "^2.0.0",
+        "domelementtype": "^2.3.0",
+        "domhandler": "^5.0.3"
+      },
+      "funding": {
+        "url": "https://github.com/fb55/domutils?sponsor=1"
+      }
+    },
     "node_modules/echarts": {
       "version": "5.5.1",
       "resolved": "https://registry.npmjs.org/echarts/-/echarts-5.5.1.tgz",
@@ -2114,6 +2166,17 @@
       "integrity": "sha512-L18DaJsXSUk2+42pv8mLs5jJT2hqFkFE4j21wOmgbUqsZ2hL72NsUU785g9RXgo3s0ZNgVl42TiHp3ZtOv/Vyg==",
       "dev": true,
       "license": "MIT"
+    },
+    "node_modules/entities": {
+      "version": "4.5.0",
+      "resolved": "https://registry.npmjs.org/entities/-/entities-4.5.0.tgz",
+      "integrity": "sha512-V0hjH4dGPh9Ao5p0MoRY6BVqtwCjhz6vI5LT8AJ55H+4g9/4vbHx1I54fS0XuclLhDHArPQCiMjDxjaL8fPxhw==",
+      "engines": {
+        "node": ">=0.12"
+      },
+      "funding": {
+        "url": "https://github.com/fb55/entities?sponsor=1"
+      }
     },
     "node_modules/es-abstract": {
       "version": "1.23.3",
@@ -3283,6 +3346,53 @@
         "node": ">= 0.4"
       }
     },
+    "node_modules/html-dom-parser": {
+      "version": "5.0.10",
+      "resolved": "https://registry.npmjs.org/html-dom-parser/-/html-dom-parser-5.0.10.tgz",
+      "integrity": "sha512-GwArYL3V3V8yU/mLKoFF7HlLBv80BZ2Ey1BzfVNRpAci0cEKhFHI/Qh8o8oyt3qlAMLlK250wsxLdYX4viedvg==",
+      "dependencies": {
+        "domhandler": "5.0.3",
+        "htmlparser2": "9.1.0"
+      }
+    },
+    "node_modules/html-react-parser": {
+      "version": "5.1.16",
+      "resolved": "https://registry.npmjs.org/html-react-parser/-/html-react-parser-5.1.16.tgz",
+      "integrity": "sha512-OtVPEQRwa4eelyMbHmUfMSw5VwJsVGSVsfa8I+M8xuV87n91cF3PHpvT/z0Frf1uG34atqh3dxgjaGIsmqVsRA==",
+      "dependencies": {
+        "domhandler": "5.0.3",
+        "html-dom-parser": "5.0.10",
+        "react-property": "2.0.2",
+        "style-to-js": "1.1.14"
+      },
+      "peerDependencies": {
+        "@types/react": "0.14 || 15 || 16 || 17 || 18",
+        "react": "0.14 || 15 || 16 || 17 || 18"
+      },
+      "peerDependenciesMeta": {
+        "@types/react": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/htmlparser2": {
+      "version": "9.1.0",
+      "resolved": "https://registry.npmjs.org/htmlparser2/-/htmlparser2-9.1.0.tgz",
+      "integrity": "sha512-5zfg6mHUoaer/97TxnGpxmbR7zJtPwIYFMZ/H5ucTlPZhKvtum05yiPK3Mgai3a0DyVxv7qYqoweaEd2nrYQzQ==",
+      "funding": [
+        "https://github.com/fb55/htmlparser2?sponsor=1",
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/fb55"
+        }
+      ],
+      "dependencies": {
+        "domelementtype": "^2.3.0",
+        "domhandler": "^5.0.3",
+        "domutils": "^3.1.0",
+        "entities": "^4.5.0"
+      }
+    },
     "node_modules/ignore": {
       "version": "5.3.2",
       "resolved": "https://registry.npmjs.org/ignore/-/ignore-5.3.2.tgz",
@@ -3338,6 +3448,11 @@
       "integrity": "sha512-k/vGaX4/Yla3WzyMCvTQOXYeIHvqOKtnqBduzTHpzpQZzAskKMhZ2K+EnBiSM9zGSoIFeMpXKxa4dYeZIQqewQ==",
       "dev": true,
       "license": "ISC"
+    },
+    "node_modules/inline-style-parser": {
+      "version": "0.2.3",
+      "resolved": "https://registry.npmjs.org/inline-style-parser/-/inline-style-parser-0.2.3.tgz",
+      "integrity": "sha512-qlD8YNDqyTKTyuITrDOffsl6Tdhv+UC4hcdAVuQsK4IMQ99nSgd1MIA/Q+jQYoh9r3hVUXhYh7urSRmXPkW04g=="
     },
     "node_modules/internal-slot": {
       "version": "1.0.7",
@@ -4502,6 +4617,11 @@
         "react-dom": "^16.8 || ^17 || ^18"
       }
     },
+    "node_modules/react-property": {
+      "version": "2.0.2",
+      "resolved": "https://registry.npmjs.org/react-property/-/react-property-2.0.2.tgz",
+      "integrity": "sha512-+PbtI3VuDV0l6CleQMsx2gtK0JZbZKbpdu5ynr+lbsuvtmgbNcS3VM0tuY2QjFNOcWxvXeHjDpy42RO+4U2rug=="
+    },
     "node_modules/react-router": {
       "version": "6.26.1",
       "resolved": "https://registry.npmjs.org/react-router/-/react-router-6.26.1.tgz",
@@ -4995,6 +5115,22 @@
       },
       "funding": {
         "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
+    "node_modules/style-to-js": {
+      "version": "1.1.14",
+      "resolved": "https://registry.npmjs.org/style-to-js/-/style-to-js-1.1.14.tgz",
+      "integrity": "sha512-+FGNddHGLPY4NOPneEEdFj8dIy+oV4mHGrPZpB38P+YXrCAG9mp70dbcsAWnM8BFZULkJRvMqD0CXRjZLOYJFA==",
+      "dependencies": {
+        "style-to-object": "1.0.7"
+      }
+    },
+    "node_modules/style-to-object": {
+      "version": "1.0.7",
+      "resolved": "https://registry.npmjs.org/style-to-object/-/style-to-object-1.0.7.tgz",
+      "integrity": "sha512-uSjr59G5u6fbxUfKbb8GcqMGT3Xs9v5IbPkjb0S16GyOeBLAzSRK0CixBv5YrYvzO6TDLzIS6QCn78tkqWngPw==",
+      "dependencies": {
+        "inline-style-parser": "0.2.3"
       }
     },
     "node_modules/styled-components": {

--- a/package.json
+++ b/package.json
@@ -14,6 +14,7 @@
     "@tanstack/react-table": "^8.20.5",
     "axios": "^1.7.7",
     "echarts": "^5.5.1",
+    "html-react-parser": "^5.1.16",
     "react": "^18.3.1",
     "react-dom": "^18.3.1",
     "react-icons": "^5.3.0",

--- a/src/components/Media/MediaDetail.tsx
+++ b/src/components/Media/MediaDetail.tsx
@@ -1,5 +1,6 @@
 import { TMedia } from "@customTypes/media";
 import { MediaContainer } from "@styles/Media.style";
+import parse from "html-react-parser";
 import styled from "styled-components";
 import NavigationControls from "./NavigationControls";
 import SnsButtons from "./SnsButtons";
@@ -31,7 +32,7 @@ const MediaDetail = ({ media }: { media: TMedia | undefined }) => {
           <h4>{media?.artcTitle}</h4>
           <TitleInfo date={media && media?.regDttm} view={media?.viewCnt} />
         </ContentHeader>
-        <MainContent dangerouslySetInnerHTML={media && { __html: media?.artcContents }}></MainContent>
+        <MainContent>{media && parse(media?.artcContents)}</MainContent>
         <SnsButtons />
       </MediaContainer>
       <NavigationControls />

--- a/src/components/Media/MediaItem.tsx
+++ b/src/components/Media/MediaItem.tsx
@@ -1,4 +1,5 @@
 import { TMedia } from "@customTypes/media";
+import { htmlToString } from "@utils/stringParsing";
 import { useNavigate } from "react-router-dom";
 import styled from "styled-components";
 import TitleInfo from "./TitleInfo";
@@ -35,7 +36,6 @@ const ArticleBox = styled.div`
 const MainContent = styled.div`
   width: 100%;
   height: 100%;
-  overflow: hidden;
 `;
 
 const MediaTitle = styled.h1`
@@ -44,16 +44,21 @@ const MediaTitle = styled.h1`
   line-height: 1.4rem;
 `;
 
-const ContentBox = styled.div`
-  width: 100%;
-  height: calc(100% - 23px);
-  margin-top: 10px;
+const ContentBox = styled.p`
+  font-size: 16px;
+  line-height: 1.4em;
+  height: 2.8em;
+  color: #666;
+  text-align: left;
   overflow: hidden;
+  text-overflow: ellipsis;
+  display: -webkit-box;
+  -webkit-line-clamp: 2;
+  -webkit-box-orient: vertical;
 `;
 
 const MediaItem = ({ media }: { media: TMedia }) => {
   const navigate = useNavigate();
-
   return (
     <ArticleContainer>
       {media.imgFilePath && <Thumbnail src={media.imgFilePath}></Thumbnail>}
@@ -63,7 +68,7 @@ const MediaItem = ({ media }: { media: TMedia }) => {
         }}>
         <MainContent>
           <MediaTitle>{media.artcTitle}</MediaTitle>
-          <ContentBox dangerouslySetInnerHTML={{ __html: media.artcContents }}></ContentBox>
+          <ContentBox>{htmlToString(media.artcContents)}</ContentBox>
         </MainContent>
         <TitleInfo date={media.regDttm} view={media.viewCnt} />
       </ArticleBox>

--- a/src/utils/stringParsing.ts
+++ b/src/utils/stringParsing.ts
@@ -1,0 +1,7 @@
+export const htmlToString = (htmlString: string): string => {
+  // 1. HTML 태그 제거
+  const noTags = htmlString.replace(/<\/?[^>]+(>|$)/g, "");
+  // 2. HTML 엔티티(&nbsp;, &amp;, etc.) 제거
+  const noEntities = noTags.replace(/&[a-zA-Z]+;/g, "");
+  return noEntities;
+};


### PR DESCRIPTION
## #️⃣ 연관된 이슈

> #62

## 📝 작업 내용

> html태그가 포함된 string을 컴포넌트로 파싱
> 미디어리스트는 태그를 없앤 string으로 변환 후, 2줄 이후는 ... 으로 변환

### 스크린샷 (선택)

>기존과 동일

## 💬 리뷰 요구사항(선택)

> html-react-parser 라이브러리 사용 (npm i 필수)
기존 dangerouslySetInnerHTML 속성은 보안에 취약하기 때문에 파싱을 위한 라이브러리 이용