### PR TITLE
미디어리스트 및 미디어상세 api연결

### DIFF
--- a/src/api/api.ts
+++ b/src/api/api.ts
@@ -4,7 +4,7 @@ declare const __BASE_URL__: string;
 
 const instance = axios.create({
   baseURL: `${__BASE_URL__}/api/`,
-  timeout: 1000,
+  timeout: 3000,
   headers: { "Content-Type": "application/json" },
 });
 export const api = async (

--- a/src/pages/News.tsx
+++ b/src/pages/News.tsx
@@ -1,13 +1,17 @@
 import MediaList from "@components/Media/MediaList";
 import { TMedia } from "@customTypes/media";
-import dummy from "@data/media.json";
+import { api } from "api/api";
 import { useEffect, useState } from "react";
 
 const News = () => {
   const [newsList, setNewsList] = useState<TMedia[]>([]);
 
   useEffect(() => {
-    setNewsList(dummy.news.list);
+    const fetchData = async () => {
+      const { data } = await api("article/newslistpage?itemCount=5&pageNum=1");
+      data && setNewsList(data.list);
+    };
+    fetchData();
   }, []);
 
   return (

--- a/src/pages/NewsDetail.tsx
+++ b/src/pages/NewsDetail.tsx
@@ -1,13 +1,19 @@
 import MediaDetail from "@components/Media/MediaDetail";
 import { TMedia } from "@customTypes/media";
-import dummy from "@data/media.json";
+import { api } from "api/api";
 import { useEffect, useState } from "react";
+import { useParams } from "react-router-dom";
 
 const NewsDetail = () => {
+  const { artcSeq } = useParams();
   const [news, setNews] = useState<TMedia>();
 
   useEffect(() => {
-    setNews(dummy.news.list[0]);
+    const fetchData = async () => {
+      const { data } = await api(`article/newsdetail?artcSeq=${artcSeq}`);
+      data && setNews(data.article);
+    };
+    fetchData();
   }, []);
 
   return (

--- a/src/pages/Press.tsx
+++ b/src/pages/Press.tsx
@@ -1,13 +1,17 @@
 import MediaList from "@components/Media/MediaList";
 import { TMedia } from "@customTypes/media";
-import dummy from "@data/media.json";
+import { api } from "api/api";
 import { useEffect, useState } from "react";
 
 const Press = () => {
   const [pressList, setPressList] = useState<TMedia[]>([]);
 
   useEffect(() => {
-    setPressList(dummy.press.list);
+    const fetchData = async () => {
+      const { data } = await api("article/wizpresslistpage?itemCount=5&pageNum=1");
+      data && setPressList(data.list);
+    };
+    fetchData();
   }, []);
 
   return (

--- a/src/pages/PressDetail.tsx
+++ b/src/pages/PressDetail.tsx
@@ -1,13 +1,19 @@
 import MediaDetail from "@components/Media/MediaDetail";
 import { TMedia } from "@customTypes/media";
-import dummy from "@data/media.json";
+import { api } from "api/api";
 import { useEffect, useState } from "react";
+import { useParams } from "react-router-dom";
 
 const PressDetail = () => {
+  const { artcSeq } = useParams();
   const [press, setPress] = useState<TMedia>();
 
   useEffect(() => {
-    setPress(dummy.press.list[0]);
+    const fetchData = async () => {
+      const { data } = await api(`article/wizpressdetail?artcSeq=${artcSeq}`);
+      data && setPress(data.article);
+    };
+    fetchData();
   }, []);
 
   return (


### PR DESCRIPTION
## #️⃣ 연관된 이슈

> ex) #43 

## 📝 작업 내용

> 미디어(뉴스,보도자료)리스트 및 상세 api연결

### 스크린샷 (선택)
기존과 동일

## 💬 리뷰 요구사항(선택)
추가 작업 필요
1. pagination을 구현하지 않아 임시로 page=1로 구현함, 추후에 구현 예정
2. img경로가 file로 되어있어 불러오지 못하는 이슈 존재, 추후에 options설정 등으로 해결 예정
3. stric모드로 인해 api연결이 두번 요청되며, timeout에러가 생겨 임시로 timeout시간을 연장함
