### PR TITLE
탭 임시 수정 및 불필요한 정보 삭제

### DIFF
--- a/src/components/ui/header/gnb/BottomMenu.tsx
+++ b/src/components/ui/header/gnb/BottomMenu.tsx
@@ -43,9 +43,6 @@ const BottomMenu = ({ $isShowNav }: NavEventType) => {
             <Link to="/ktwiz/policy">회원 정책</Link>
           </li>
           <li>
-            <Link to="/ktwiz/sponsor">스폰서</Link>
-          </li>
-          <li>
             <Link to="/ktwiz/wallpaper">월페이퍼</Link>
           </li>
         </ul>

--- a/src/data/nav.json
+++ b/src/data/nav.json
@@ -197,6 +197,18 @@
       {
         "id": 4,
         "desc": "오늘의 관전 포인트를 알려 드립니다."
+      },
+      {
+        "id": 5,
+        "desc": "kt wiz의 투수 기록을 알려드립니다."
+      },
+      {
+        "id": 6,
+        "desc": "kt wiz의 타자 기록을 알려드립니다."
+      },
+      {
+        "id": 7,
+        "desc": "kkt wiz의 관중현황을 알려드립니다."
       }
     ],
     "path": [
@@ -210,11 +222,23 @@
       },
       {
         "id": 3,
-        "path": "/game/ranking"
+        "path": "/game/ranking/team"
       },
       {
         "id": 4,
         "path": "/game/watchPoint"
+      },
+      {
+        "id": 5,
+        "path": "/game/ranking/pitcher"
+      },
+      {
+        "id": 6,
+        "path": "/game/ranking/batter"
+      },
+      {
+        "id": 7,
+        "path": "/game/ranking/crowd"
       }
     ],
     "tab": [
@@ -244,6 +268,10 @@
       {
         "id": 1,
         "path": "/player/coach"
+      },
+      {
+        "id": 2,
+        "path": "/player/coach/detail"
       }
     ]
   },
@@ -255,6 +283,10 @@
       {
         "id": 1,
         "path": "/player/pitcher"
+      },
+      {
+        "id": 2,
+        "path": "/player/pitcher/detail"
       }
     ]
   },
@@ -274,6 +306,18 @@
       {
         "id": 3,
         "path": "/player/outfielder"
+      },
+      {
+        "id": 4,
+        "path": "/player/catcher/detail"
+      },
+      {
+        "id": 5,
+        "path": "/player/infielder/detail"
+      },
+      {
+        "id": 6,
+        "path": "/player/outfielder/detail"
       }
     ],
     "tab": [

--- a/src/data/nav.json
+++ b/src/data/nav.json
@@ -128,20 +128,6 @@
       {
         "id": 1,
         "path": "/wizpark/intro"
-      },
-      {
-        "id": 2,
-        "path": "/wizpark/guide"
-      }
-    ],
-    "tab": [
-      {
-        "id": 1,
-        "tab": "구장 소개"
-      },
-      {
-        "id": 2,
-        "tab": "구장 안내도"
       }
     ]
   },


### PR DESCRIPTION
## #️⃣ 연관된 이슈

> #77

## 📝 작업 내용

1. tab이 보이도록 수정 (player상세, game순위기록의 각 탭)
2. 중복되는 스폰서와 구장안내도는 삭제함, 다른 페이지에서 구현 예정

## 💬 리뷰 요구사항(선택)
1. tab로직 수정이 필요합니다. 지금은 임시로 path를 넣어 새로고침하면 탭이 처음으로 이동하는 문제가 있습니다.
2. 순위기록의 각 탭은 아직 라우터가 없어 누를경우 에러가 발생합니다.
