### PR TITLE
player radar 차트 마크업 및 데이터 패칭

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -11,7 +11,7 @@
         "@tanstack/react-query": "^5.53.2",
         "@tanstack/react-table": "^8.20.5",
         "axios": "^1.7.7",
-        "echarts": "^5.5.1",
+        "echarts-for-react": "^3.0.2",
         "html-react-parser": "^5.1.16",
         "react": "^18.3.1",
         "react-dom": "^18.3.1",
@@ -2149,16 +2149,32 @@
       "resolved": "https://registry.npmjs.org/echarts/-/echarts-5.5.1.tgz",
       "integrity": "sha512-Fce8upazaAXUVUVsjgV6mBnGuqgO+JNDlcgF79Dksy4+wgGpQB2lmYoO4TSweFg/mZITdpGHomw/cNBJZj1icA==",
       "license": "Apache-2.0",
+      "peer": true,
       "dependencies": {
         "tslib": "2.3.0",
         "zrender": "5.6.0"
+      }
+    },
+    "node_modules/echarts-for-react": {
+      "version": "3.0.2",
+      "resolved": "https://registry.npmjs.org/echarts-for-react/-/echarts-for-react-3.0.2.tgz",
+      "integrity": "sha512-DRwIiTzx8JfwPOVgGttDytBqdp5VzCSyMRIxubgU/g2n9y3VLUmF2FK7Icmg/sNVkv4+rktmrLN9w22U2yy3fA==",
+      "license": "MIT",
+      "dependencies": {
+        "fast-deep-equal": "^3.1.3",
+        "size-sensor": "^1.0.1"
+      },
+      "peerDependencies": {
+        "echarts": "^3.0.0 || ^4.0.0 || ^5.0.0",
+        "react": "^15.0.0 || >=16.0.0"
       }
     },
     "node_modules/echarts/node_modules/tslib": {
       "version": "2.3.0",
       "resolved": "https://registry.npmjs.org/tslib/-/tslib-2.3.0.tgz",
       "integrity": "sha512-N82ooyxVNm6h1riLCoyS9e3fuJ3AMG2zIZs2Gd1ATcSFjSA23Q0fzjjZeh0jbJvWVDZ0cJT8yaNNaaXHzueNjg==",
-      "license": "0BSD"
+      "license": "0BSD",
+      "peer": true
     },
     "node_modules/emoji-regex": {
       "version": "9.2.2",
@@ -2894,7 +2910,6 @@
       "version": "3.1.3",
       "resolved": "https://registry.npmjs.org/fast-deep-equal/-/fast-deep-equal-3.1.3.tgz",
       "integrity": "sha512-f3qQ9oQy9j2AhBe/H9VC91wLmKBCCU/gDOnKNAYG5hswO7BLKj09Hc5HYNz9cGI++xlpDCIgDaitVs03ATR84Q==",
-      "dev": true,
       "license": "MIT"
     },
     "node_modules/fast-diff": {
@@ -4958,6 +4973,12 @@
         "url": "https://github.com/sponsors/ljharb"
       }
     },
+    "node_modules/size-sensor": {
+      "version": "1.0.2",
+      "resolved": "https://registry.npmjs.org/size-sensor/-/size-sensor-1.0.2.tgz",
+      "integrity": "sha512-2NCmWxY7A9pYKGXNBfteo4hy14gWu47rg5692peVMst6lQLPKrVjhY+UTEsPI5ceFRJSl3gVgMYaUi/hKuaiKw==",
+      "license": "ISC"
+    },
     "node_modules/source-map-js": {
       "version": "1.2.0",
       "resolved": "https://registry.npmjs.org/source-map-js/-/source-map-js-1.2.0.tgz",
@@ -5745,6 +5766,7 @@
       "resolved": "https://registry.npmjs.org/zrender/-/zrender-5.6.0.tgz",
       "integrity": "sha512-uzgraf4njmmHAbEUxMJ8Oxg+P3fT04O+9p7gY+wJRVxo8Ge+KmYv0WJev945EH4wFuc4OY2NLXz46FZrWS9xJg==",
       "license": "BSD-3-Clause",
+      "peer": true,
       "dependencies": {
         "tslib": "2.3.0"
       }
@@ -5753,7 +5775,8 @@
       "version": "2.3.0",
       "resolved": "https://registry.npmjs.org/tslib/-/tslib-2.3.0.tgz",
       "integrity": "sha512-N82ooyxVNm6h1riLCoyS9e3fuJ3AMG2zIZs2Gd1ATcSFjSA23Q0fzjjZeh0jbJvWVDZ0cJT8yaNNaaXHzueNjg==",
-      "license": "0BSD"
+      "license": "0BSD",
+      "peer": true
     },
     "node_modules/zustand": {
       "version": "4.5.5",

--- a/package.json
+++ b/package.json
@@ -13,7 +13,7 @@
     "@tanstack/react-query": "^5.53.2",
     "@tanstack/react-table": "^8.20.5",
     "axios": "^1.7.7",
-    "echarts": "^5.5.1",
+    "echarts-for-react": "^3.0.2",
     "html-react-parser": "^5.1.16",
     "react": "^18.3.1",
     "react-dom": "^18.3.1",

--- a/src/components/Player/PlayerChart.tsx
+++ b/src/components/Player/PlayerChart.tsx
@@ -13,8 +13,8 @@ const PlayerChart = ({ isPitcher, data }: { isPitcher: boolean; data: number[] }
 
   const indicator = isPitcher
     ? [
-        { name: "평균 자책점", max: 6 },
-        { name: "WHIP", max: 2 },
+        { name: "6-평균 자책점", max: 6 },
+        { name: "2-WHIP", max: 2 },
         { name: "탈삼진", max: 300 },
         { name: "이닝", max: 250 },
         { name: "승률", max: 1 },
@@ -30,6 +30,9 @@ const PlayerChart = ({ isPitcher, data }: { isPitcher: boolean; data: number[] }
       ];
 
   const option = {
+    tooltip: {
+      trigger: "item",
+    },
     legend: {
       data: [player?.playerName],
       left: "30%",
@@ -47,6 +50,11 @@ const PlayerChart = ({ isPitcher, data }: { isPitcher: boolean; data: number[] }
             name: player?.playerName,
           },
         ],
+        itemStyle: {
+          color: "#ec0a0b",
+        },
+        symbol: "circle",
+        symbolSize: 7,
       },
     ],
   };

--- a/src/components/Player/PlayerChart.tsx
+++ b/src/components/Player/PlayerChart.tsx
@@ -1,0 +1,62 @@
+import ReactECharts from "echarts-for-react";
+import { usePlayerStore } from "store/actions/usePlayerStore";
+import styled from "styled-components";
+
+const ChartWrapper = styled.div`
+  margin-top: 40px;
+`;
+
+const PlayerChart = ({ isPitcher, data }: { isPitcher: boolean; data: number[] }) => {
+  const player = usePlayerStore((state) => state.player);
+
+  if (!player) return <></>;
+
+  const indicator = isPitcher
+    ? [
+        { name: "평균 자책점", max: 6 },
+        { name: "WHIP", max: 2 },
+        { name: "탈삼진", max: 300 },
+        { name: "이닝", max: 250 },
+        { name: "승률", max: 1 },
+        { name: "삼진/볼넷", max: 10 },
+      ]
+    : [
+        { name: "타율", max: 0.4 },
+        { name: "홈런", max: 60 },
+        { name: "타점", max: 150 },
+        { name: "출루율", max: 0.5 },
+        { name: "장타율", max: 0.7 },
+        { name: "도루", max: 60 },
+      ];
+
+  const option = {
+    legend: {
+      data: [player?.playerName],
+      left: "30%",
+    },
+    radar: {
+      indicator: indicator,
+    },
+    series: [
+      {
+        name: isPitcher ? "투수 기록" : "타자 기록",
+        type: "radar",
+        data: [
+          {
+            value: data,
+            name: player?.playerName,
+          },
+        ],
+      },
+    ],
+  };
+
+  return (
+    <>
+      <ChartWrapper>
+        <ReactECharts option={option} notMerge={true} lazyUpdate={true} />
+      </ChartWrapper>
+    </>
+  );
+};
+export default PlayerChart;

--- a/src/components/Player/PlayerDetail.tsx
+++ b/src/components/Player/PlayerDetail.tsx
@@ -28,7 +28,9 @@ import {
   pitTotalHeaders,
 } from "data/playerHeaders";
 import { useState } from "react";
+import { usePlayerStore } from "store/actions/usePlayerStore";
 import styled from "styled-components";
+import PlayerChart from "./PlayerChart";
 import PlayerTable from "./PlayerTable";
 
 const DetailMenuWrapper = styled.div`
@@ -62,6 +64,10 @@ const PlayerDetail = ({ isPitcher }: { isPitcher: boolean }) => {
   const [menu, setMenu] = useState("league");
   const [title, setTitle] = useState("2024 시즌 정규리그 기록");
 
+  const pitcherSeasonSummary = usePlayerStore((state) => state.pitcherSeasonSummary);
+  const hitterSeasonSummary = usePlayerStore((state) => state.hitterSeasonSummary);
+
+  if ((!isPitcher && !hitterSeasonSummary) || (isPitcher && !pitcherSeasonSummary)) return <></>;
   // 필터링된 데이터
   const filteredPitchers: FilterPitcherType[] = pitcherData.map(filterPitcherData);
   const filteredPitchers2: FilterPitcherType2[] = pitcherData.map(filterPitcherData2);
@@ -123,17 +129,38 @@ const PlayerDetail = ({ isPitcher }: { isPitcher: boolean }) => {
               <PlayerTable<FilterPitcherType> resData={filteredPitchers} headers={pitcherHeaders} />
               <TableMargin />
               <PlayerTable<FilterPitcherType2> resData={filteredPitchers2} headers={pitcherHeaders2} />
-              {/* <PitcherTable />
-              <PitcherTable2 /> */}
+              {pitcherSeasonSummary && (
+                <PlayerChart
+                  isPitcher={isPitcher}
+                  data={[
+                    Number(pitcherSeasonSummary.era) < 6 ? 6 - Number(pitcherSeasonSummary.era) : 0,
+                    Number(pitcherSeasonSummary.whip) < 2 ? 2 - Number(pitcherSeasonSummary.whip) : 0,
+                    pitcherSeasonSummary.kk,
+                    Number(pitcherSeasonSummary.innDisplay),
+                    Number(pitcherSeasonSummary.wra),
+                    Number(pitcherSeasonSummary.kbb),
+                  ]}
+                />
+              )}
             </>
           ) : (
             <>
               <PlayerTable<FilterHitterType> resData={filteredHitters} headers={hitterHeaders} />
               <TableMargin />
               <PlayerTable<FilterHitterType2> resData={filteredHitters2} headers={hitterHeaders2} />
-
-              {/* <HitterTable />
-              <HitterTable2 /> */}
+              {hitterSeasonSummary && (
+                <PlayerChart
+                  isPitcher={isPitcher}
+                  data={[
+                    Number(hitterSeasonSummary.hra),
+                    hitterSeasonSummary.hr,
+                    hitterSeasonSummary.rbi,
+                    Number(hitterSeasonSummary.bra),
+                    Number(hitterSeasonSummary.slg),
+                    hitterSeasonSummary.sb,
+                  ]}
+                />
+              )}
             </>
           ))}
         {menu === "recent" &&

--- a/src/components/Player/PlayerDetail.tsx
+++ b/src/components/Player/PlayerDetail.tsx
@@ -133,10 +133,14 @@ const PlayerDetail = ({ isPitcher }: { isPitcher: boolean }) => {
                 <PlayerChart
                   isPitcher={isPitcher}
                   data={[
-                    Number(pitcherSeasonSummary.era) < 6 ? 6 - Number(pitcherSeasonSummary.era) : 0,
-                    Number(pitcherSeasonSummary.whip) < 2 ? 2 - Number(pitcherSeasonSummary.whip) : 0,
+                    Number(pitcherSeasonSummary.era) < 6
+                      ? Math.round((6 - parseFloat(pitcherSeasonSummary.era)) * 100) / 100
+                      : 0,
+                    Number(pitcherSeasonSummary.whip) < 2
+                      ? Math.round((2 - parseFloat(pitcherSeasonSummary.whip)) * 100) / 100
+                      : 0,
                     pitcherSeasonSummary.kk,
-                    Number(pitcherSeasonSummary.innDisplay),
+                    Math.floor(pitcherSeasonSummary.inn2 / 3),
                     Number(pitcherSeasonSummary.wra),
                     Number(pitcherSeasonSummary.kbb),
                   ]}

--- a/src/store/actions/usePlayerStore.ts
+++ b/src/store/actions/usePlayerStore.ts
@@ -29,14 +29,14 @@ export const usePlayerStore = create<PlayerStoreType>((set) => ({
       url === "pitcher" &&
         set({
           player: data.data.gameplayer,
-          pitcherSeasonSummary: data.data.seasonsummary,
+          pitcherSeasonSummary: data.data.seasonsummary ? data.data.seasonsummary : data.data.seasonsummaryfutures,
           pitcherRecentRecordList: data.data.recentgamerecordlist,
           pitcherYearRecordList: data.data.yearrecordlist,
         });
       (url === "catcher" || url === "infielder" || url === "outfielder") &&
         set({
           player: data.data.gameplayer,
-          hitterSeasonSummary: data.data.seasonsummary,
+          hitterSeasonSummary: data.data.seasonsummary ? data.data.seasonsummary : data.data.seasonsummaryfutures,
           hitterRecentRecordList: data.data.recentgamerecordlist,
           hitterYearRecordList: data.data.yearrecordlist,
         });


### PR DESCRIPTION
## #️⃣ 연관된 이슈

> #105 

## 📝 작업 내용

> player radar 차트 마크업 및 데이터 패칭

### 스크린샷 (선택)
![image](https://github.com/user-attachments/assets/fe79b307-a1c1-418a-b21d-9229c286b003)

---


![image](https://github.com/user-attachments/assets/0d6eee4d-12c4-4622-93b5-e30f8bbff189)

## 💬 리뷰 요구사항(선택)

> 차트에만 데이터 패칭 완료된 상태입니다. 테이블은 목업데이터 사용하고 있어요.
> 평균자책점과 whip는 숫자가 클 수록 안좋아서 -로 처리한 상태입니다. 더 나은 방법이 있을까요?
> 6개의 중요 데이터는 gpt를 통해 골랐습니다. 바꾸거나 추가하고 싶은 데이터 있으시면 의견 부탁드립니다.
