### PR TITLE
관중현황 페이지 관중기록 테이블 API 연동

### DIFF
--- a/src/components/Audience/AccrueAudience.tsx
+++ b/src/components/Audience/AccrueAudience.tsx
@@ -1,20 +1,10 @@
 import ArticleTitle from "@components/common/ArticleTitle";
 import ReactECharts from "echarts-for-react";
+import { useEffect, useState } from "react";
 import styled from "styled-components";
+import { api } from "../../api/api.ts";
+import { Tcrowd } from "../../types/Crowd";
 
-// 더미 데이터
-const data = [
-  { team: "KT", value: 700000 },
-  { team: "LG", value: 1300000 },
-  { team: "삼성", value: 1250000 },
-  { team: "두산", value: 1200000 },
-  { team: "KIA", value: 1150000 },
-  { team: "롯데", value: 1200000 },
-  { team: "SSG", value: 1150000 },
-  { team: "키움", value: 900000 },
-  { team: "한화", value: 950000 },
-  { team: "NC", value: 850000 },
-];
 const StyledArticle = styled.article`
   width: 100%;
   height: 435px;
@@ -22,9 +12,22 @@ const StyledArticle = styled.article`
 `;
 
 const AccrueAudience = () => {
-  // xAxis와 yAxis에 사용할 데이터
-  const teams = data.map((item) => item.team);
-  const values = data.map((item) => item.value);
+  const [crowdData, setCrowdData] = useState<Tcrowd[]>([]);
+
+  useEffect(() => {
+    const fetchData = async () => {
+      const { data } = await api("game/rank/crowd?gyear=2024");
+
+      const teamOrder = ["KT", "LG", "삼성", "두산", "KIA", "롯데", "SSG", "키움", "한화", "NC"];
+
+      const sortedData = teamOrder.map((team) => data.list.find((item: Tcrowd) => item.teamName === team));
+      setCrowdData(sortedData);
+    };
+    fetchData();
+  }, []);
+
+  const teams = crowdData.map((item) => item?.teamName);
+  const values = crowdData.map((item) => item?.crowd || 0);
 
   const options = {
     tooltip: {
@@ -40,17 +43,17 @@ const AccrueAudience = () => {
       bottom: "6%",
     },
     xAxis: {
-      type: "category", // 팀 이름을 x축에 표시
+      type: "category",
       data: teams,
       axisLabel: {
         interval: 0,
-        rotate: 0, // x축 라벨을 기울여서 표시
+        rotate: 0,
         margin: 5,
         verticalAlign: "top",
       },
     },
     yAxis: {
-      type: "value", // y축은 직접 설정한 값 사용
+      type: "value",
       axisLabel: {
         formatter: (value: number) => value.toLocaleString(),
       },
@@ -60,25 +63,23 @@ const AccrueAudience = () => {
     },
     series: [
       {
-        data: values, // 팀별 관중 수 데이터
-        type: "bar", // 막대형 차트로 설정
+        data: values,
+        type: "bar",
         itemStyle: {
-          color: (params: any) => (params.dataIndex === 0 ? "#d73027" : "#4a4a4a"), // KT팀은 빨간색, 나머지는 회색
+          color: (params: any) => (params.dataIndex === 0 ? "#d73027" : "#4a4a4a"),
         },
-        barWidth: "15%", // 막대 너비 설정
+        barWidth: "15%",
       },
     ],
   };
 
   return (
-    <>
-      <StyledArticle>
-        <ArticleTitle title="2024 시즌 누적관중" />
-        <div style={{ border: "1px solid black", width: "100%", height: "350px" }}>
-          <ReactECharts option={options} style={{ width: "100%", height: "300px" }} opts={{ renderer: "svg" }} />
-        </div>
-      </StyledArticle>
-    </>
+    <StyledArticle>
+      <ArticleTitle title="2024 시즌 누적관중" />
+      <div style={{ border: "1px solid black", width: "100%", height: "350px" }}>
+        <ReactECharts option={options} style={{ width: "100%", height: "300px" }} opts={{ renderer: "svg" }} />
+      </div>
+    </StyledArticle>
   );
 };
 

--- a/src/components/Audience/AccrueAudience.tsx
+++ b/src/components/Audience/AccrueAudience.tsx
@@ -1,13 +1,85 @@
 import ArticleTitle from "@components/common/ArticleTitle";
-import { StyledArticle } from "@styles/Ranking.style";
+import ReactECharts from "echarts-for-react";
+import styled from "styled-components";
+
+// 더미 데이터
+const data = [
+  { team: "KT", value: 700000 },
+  { team: "LG", value: 1300000 },
+  { team: "삼성", value: 1250000 },
+  { team: "두산", value: 1200000 },
+  { team: "KIA", value: 1150000 },
+  { team: "롯데", value: 1200000 },
+  { team: "SSG", value: 1150000 },
+  { team: "키움", value: 900000 },
+  { team: "한화", value: 950000 },
+  { team: "NC", value: 850000 },
+];
+const StyledArticle = styled.article`
+  width: 100%;
+  height: 435px;
+  margin-top: 45px;
+`;
 
 const AccrueAudience = () => {
+  // xAxis와 yAxis에 사용할 데이터
+  const teams = data.map((item) => item.team);
+  const values = data.map((item) => item.value);
+
+  const options = {
+    tooltip: {
+      trigger: "item",
+      formatter: (params: any) => {
+        return `${params.name}: ${params.value.toLocaleString()}`;
+      },
+    },
+    grid: {
+      left: "7%",
+      top: "25%",
+      right: "15px",
+      bottom: "6%",
+    },
+    xAxis: {
+      type: "category", // 팀 이름을 x축에 표시
+      data: teams,
+      axisLabel: {
+        interval: 0,
+        rotate: 0, // x축 라벨을 기울여서 표시
+        margin: 5,
+        verticalAlign: "top",
+      },
+    },
+    yAxis: {
+      type: "value", // y축은 직접 설정한 값 사용
+      axisLabel: {
+        formatter: (value: number) => value.toLocaleString(),
+      },
+      min: 0,
+      max: 1600000,
+      interval: 200000,
+    },
+    series: [
+      {
+        data: values, // 팀별 관중 수 데이터
+        type: "bar", // 막대형 차트로 설정
+        itemStyle: {
+          color: (params: any) => (params.dataIndex === 0 ? "#d73027" : "#4a4a4a"), // KT팀은 빨간색, 나머지는 회색
+        },
+        barWidth: "15%", // 막대 너비 설정
+      },
+    ],
+  };
+
   return (
     <>
       <StyledArticle>
         <ArticleTitle title="2024 시즌 누적관중" />
+        <div style={{ border: "1px solid black", width: "100%", height: "350px" }}>
+          <ReactECharts option={options} style={{ width: "100%", height: "300px" }} opts={{ renderer: "svg" }} />
+        </div>
       </StyledArticle>
     </>
   );
 };
+
 export default AccrueAudience;

--- a/src/components/Audience/AudienceRecord.tsx
+++ b/src/components/Audience/AudienceRecord.tsx
@@ -1,6 +1,5 @@
 import ArticleTitle from "@components/common/ArticleTitle";
 import { Tcrowd } from "@customTypes/Crowd";
-import { StyledArticle } from "@styles/Ranking.style";
 import { useEffect, useState } from "react";
 import styled from "styled-components";
 import { api } from "../../api/api.ts";
@@ -49,6 +48,12 @@ const HighlightRow = styled.tr`
     color: #ec0a0b;
   }
 `;
+
+const StyledArticle = styled.article`
+  width: 100%;
+  height: 435px;
+`;
+
 const AudienceRecord = () => {
   const [crowdData, setCrowdData] = useState<Tcrowd[]>([]);
 

--- a/src/components/Audience/AudienceRecord.tsx
+++ b/src/components/Audience/AudienceRecord.tsx
@@ -1,27 +1,10 @@
 import ArticleTitle from "@components/common/ArticleTitle";
+import { Tcrowd } from "@customTypes/Crowd";
 import { StyledArticle } from "@styles/Ranking.style";
+import { useEffect, useState } from "react";
 import styled from "styled-components";
-interface TeamData {
-  rank: number;
-  team: string;
-  games: number;
-  totalAttendance: number;
-  avgAttendance: number;
-}
+import { api } from "../../api/api.ts";
 
-// 임의 데이터
-const teamData: TeamData[] = [
-  { rank: 1, team: "LG", games: 68, totalAttendance: 1281420, avgAttendance: 18844 },
-  { rank: 2, team: "삼성", games: 70, totalAttendance: 1275022, avgAttendance: 18215 },
-  { rank: 3, team: "두산", games: 69, totalAttendance: 1257215, avgAttendance: 18221 },
-  { rank: 4, team: "KIA", games: 69, totalAttendance: 1177249, avgAttendance: 17062 },
-  { rank: 5, team: "롯데", games: 68, totalAttendance: 1168597, avgAttendance: 17185 },
-  { rank: 6, team: "SSG", games: 69, totalAttendance: 1100862, avgAttendance: 15955 },
-  { rank: 7, team: "키움", games: 72, totalAttendance: 792350, avgAttendance: 11005 },
-  { rank: 8, team: "KT", games: 66, totalAttendance: 768260, avgAttendance: 11640 },
-  { rank: 9, team: "한화", games: 66, totalAttendance: 745797, avgAttendance: 11300 },
-  { rank: 10, team: "NC", games: 69, totalAttendance: 700742, avgAttendance: 10156 },
-];
 const TableWrapper = styled.div`
   max-width: 1200px;
   margin: 0 auto;
@@ -67,6 +50,15 @@ const HighlightRow = styled.tr`
   }
 `;
 const AudienceRecord = () => {
+  const [crowdData, setCrowdData] = useState<Tcrowd[]>([]);
+
+  useEffect(() => {
+    const fetchData = async () => {
+      const { data } = await api("game/rank/crowd?gyear=2024");
+      setCrowdData(data.list);
+    };
+    fetchData();
+  }, []);
   return (
     <>
       <StyledArticle>
@@ -83,22 +75,22 @@ const AudienceRecord = () => {
               </tr>
             </TableHeader>
             <TableBody>
-              {teamData.map((team) =>
-                team.team === "KT" ? (
-                  <HighlightRow key={team.rank}>
-                    <td>{team.rank}</td>
-                    <td>{team.team}</td>
-                    <td>{team.games}</td>
-                    <td>{team.totalAttendance.toLocaleString()}</td>
-                    <td>{team.avgAttendance.toLocaleString()}</td>
+              {crowdData.map((team, index) =>
+                team.teamName === "KT" ? (
+                  <HighlightRow key={index}>
+                    <td>{index + 1}</td>
+                    <td>{team.teamName}</td>
+                    <td>{team.game}</td>
+                    <td>{team.crowd.toLocaleString()}</td>
+                    <td>{team.crowd.toLocaleString()}</td>
                   </HighlightRow>
                 ) : (
-                  <tr key={team.rank}>
-                    <td>{team.rank}</td>
-                    <td>{team.team}</td>
-                    <td>{team.games}</td>
-                    <td>{team.totalAttendance.toLocaleString()}</td>
-                    <td>{team.avgAttendance.toLocaleString()}</td>
+                  <tr key={index}>
+                    <td>{index + 1}</td>
+                    <td>{team.teamName}</td>
+                    <td>{team.game}</td>
+                    <td>{team.crowd.toLocaleString()}</td>
+                    <td>{team.crowd.toLocaleString()}</td>
                   </tr>
                 )
               )}

--- a/src/components/Audience/AudienceRecord.tsx
+++ b/src/components/Audience/AudienceRecord.tsx
@@ -87,7 +87,7 @@ const AudienceRecord = () => {
                     <td>{team.teamName}</td>
                     <td>{team.game}</td>
                     <td>{team.crowd.toLocaleString()}</td>
-                    <td>{team.crowd.toLocaleString()}</td>
+                    <td>{Math.floor(team.crowd / team.game).toLocaleString()}</td>
                   </HighlightRow>
                 ) : (
                   <tr key={index}>
@@ -95,7 +95,7 @@ const AudienceRecord = () => {
                     <td>{team.teamName}</td>
                     <td>{team.game}</td>
                     <td>{team.crowd.toLocaleString()}</td>
-                    <td>{team.crowd.toLocaleString()}</td>
+                    <td>{Math.floor(team.crowd / team.game).toLocaleString()}</td>
                   </tr>
                 )
               )}

--- a/src/types/Crowd.d.ts
+++ b/src/types/Crowd.d.ts
@@ -1,0 +1,6 @@
+export type Tcrowd = {
+  crowd: number;
+  game: number;
+  teamCode: string;
+  teamName: string;
+};


### PR DESCRIPTION
## #️⃣ 연관된 이슈

> ex) #이슈번호, #이슈번호

## 📝 작업 내용

> 관중현황 페이지 관중 기록 테이블 API 연동했습니다. 근데 API 데이터에는 평균 관중 데이터가 없어서 일단 누적 관중으로 넣어놨습니다. 내일 멘토님께 문의 드려보겠습니다! 이것떄문에 WIP 로 pr 남겼습니다! -> 해결 했습니다!!
<img width="917" alt="스크린샷 2024-09-23 오후 10 01 56" src="https://github.com/user-attachments/assets/39c42113-90d6-488f-9ea5-4fdf96390a8d">
관중 현황 페이지 관중 기록 테이블 API 연동 완료 했습니다.

관중현황 페이지 관중 기록 그래프 API 불러와서 데이터 정렬해서 적용했씁니다!
<img width="917" alt="스크린샷 2024-09-23 오후 9 54 23" src="https://github.com/user-attachments/assets/e9a8b10e-d365-4782-8883-d503967fd9b5">





### 스크린샷 (선택)

## 💬 리뷰 요구사항(선택)
관중 현황 페이지 API 작업 예정입니다. 

