### PR TITLE
tanstack query Box Score 적용

### DIFF
--- a/src/components/BoxScore/BoxScoreInfo.tsx
+++ b/src/components/BoxScore/BoxScoreInfo.tsx
@@ -1,6 +1,8 @@
 import { FilterScoreboardType } from "@customTypes/boxScore";
 import { stringDate } from "@utils/date";
 import { filterScoreboardData } from "@utils/filterBoxScoreData";
+import { useBoxScoreQuery } from "hooks/useBoxScore";
+import { useState } from "react";
 import { GrNext, GrPrevious } from "react-icons/gr";
 import { useGameStore } from "store/actions/useGameStore";
 import styled from "styled-components";
@@ -24,9 +26,11 @@ const BoxScoreButton = styled.button`
   color: #fff;
   border-radius: 50%;
   font-size: 12px;
+  cursor: not-allowed;
 
   &.active {
     background-color: #35383e;
+    cursor: pointer;
   }
 `;
 
@@ -97,9 +101,13 @@ const Logo = styled.span<{ $img: string }>`
 const BoxScoreInfo = () => {
   const schedule = useGameStore((state) => state.schedule);
   const scoreBoard = useGameStore((state) => state.scoreBoard);
-  const fetchBoxScore = useGameStore((state) => state.fetchBoxScore);
+  const setDaySchedule = useGameStore(state => state.setDaySchedule)
 
   const filterScoreBoard = scoreBoard?.map(filterScoreboardData);
+
+  const fetchHandler = (gameDate: string, gmkey: string) => {
+    setDaySchedule({ gameDate, gmkey });
+  };
 
   if (!schedule) return <></>;
 
@@ -112,13 +120,13 @@ const BoxScoreInfo = () => {
           <div>
             <BoxScoreButton
               className={schedule.prev ? "active" : ""}
-              onClick={() => fetchBoxScore(schedule.prev.gameDate.toString(), schedule.prev.gmkey)}>
+              onClick={() => schedule.prev && fetchHandler(schedule.prev.gameDate.toString(), schedule.prev.gmkey)}>
               <GrPrevious fontSize={"1.5em"} />
             </BoxScoreButton>
             <DateSpan>{stringDate(schedule.current.gameDate.toString())}</DateSpan>
             <BoxScoreButton
               className={schedule.next ? "active" : ""}
-              onClick={() => fetchBoxScore(schedule.next.gameDate.toString(), schedule.next.gmkey)}>
+              onClick={() => schedule.next && fetchHandler(schedule.next.gameDate.toString(), schedule.next.gmkey)}>
               <GrNext fontSize={"1.5em"} />
             </BoxScoreButton>
           </div>

--- a/src/components/BoxScore/BoxScoreInfo.tsx
+++ b/src/components/BoxScore/BoxScoreInfo.tsx
@@ -1,8 +1,6 @@
 import { FilterScoreboardType } from "@customTypes/boxScore";
 import { stringDate } from "@utils/date";
 import { filterScoreboardData } from "@utils/filterBoxScoreData";
-import { useBoxScoreQuery } from "hooks/useBoxScore";
-import { useState } from "react";
 import { GrNext, GrPrevious } from "react-icons/gr";
 import { useGameStore } from "store/actions/useGameStore";
 import styled from "styled-components";
@@ -101,7 +99,7 @@ const Logo = styled.span<{ $img: string }>`
 const BoxScoreInfo = () => {
   const schedule = useGameStore((state) => state.schedule);
   const scoreBoard = useGameStore((state) => state.scoreBoard);
-  const setDaySchedule = useGameStore(state => state.setDaySchedule)
+  const setDaySchedule = useGameStore((state) => state.setDaySchedule);
 
   const filterScoreBoard = scoreBoard?.map(filterScoreboardData);
 

--- a/src/hooks/useBoxScore.ts
+++ b/src/hooks/useBoxScore.ts
@@ -1,0 +1,38 @@
+import { useQuery } from "@tanstack/react-query";
+import { api } from "api/api";
+import { useGameStore } from "store/actions/useGameStore";
+
+export const useDayScheduleQuery = () => {
+  const setDaySchedule = useGameStore((state) => state.setDaySchedule); // Zustand setter
+  return useQuery({
+    queryKey: ["daySchedule"],
+    queryFn: async () => {
+      const data = await api("game/recentGames");
+      setDaySchedule(data.data.current);
+      return data.data.current;
+    },
+  });
+};
+
+export const useBoxScoreQuery = (gameDate?: string, gmkey?: string) => {
+  const setBoxScore = useGameStore((state) => state.setBoxScore);
+
+  if (!gameDate && !gmkey)
+    return useQuery({
+      queryKey: ["boxScore", gameDate, gmkey],
+      queryFn: async () => {
+        const data = await api(`game/boxscore`);
+        setBoxScore(data.data);
+        return data;
+      },
+    });
+
+  return useQuery({
+    queryKey: ["boxScore", gameDate, gmkey],
+    queryFn: async () => {
+      const data = await api(`game/boxscore?gameDate=${gameDate}&gmkey=${gmkey}`);
+      setBoxScore(data.data);
+      return data.data;
+    },
+  });
+};

--- a/src/hooks/useBoxScore.ts
+++ b/src/hooks/useBoxScore.ts
@@ -2,18 +2,6 @@ import { useQuery } from "@tanstack/react-query";
 import { api } from "api/api";
 import { useGameStore } from "store/actions/useGameStore";
 
-export const useDayScheduleQuery = () => {
-  const setDaySchedule = useGameStore((state) => state.setDaySchedule); // Zustand setter
-  return useQuery({
-    queryKey: ["daySchedule"],
-    queryFn: async () => {
-      const data = await api("game/recentGames");
-      setDaySchedule(data.data.current);
-      return data.data.current;
-    },
-  });
-};
-
 export const useBoxScoreQuery = (gameDate?: string, gmkey?: string) => {
   const setBoxScore = useGameStore((state) => state.setBoxScore);
 

--- a/src/main.tsx
+++ b/src/main.tsx
@@ -1,12 +1,17 @@
 import GlobalStyle from "@styles/GlobalStyle";
+import { QueryClient, QueryClientProvider } from "@tanstack/react-query";
 import { StrictMode } from "react";
 import { createRoot } from "react-dom/client";
 import { RouterProvider } from "react-router-dom";
 import { router } from "router/index.tsx";
 
+const queryClient = new QueryClient();
+
 createRoot(document.getElementById("root")!).render(
   <StrictMode>
     <GlobalStyle />
-    <RouterProvider router={router} />
+    <QueryClientProvider client={queryClient}>
+      <RouterProvider router={router} />
+    </QueryClientProvider>
   </StrictMode>
 );

--- a/src/pages/BoxScore.tsx
+++ b/src/pages/BoxScore.tsx
@@ -4,7 +4,7 @@ import PlayerTable from "@components/Player/PlayerTable";
 import { FilterGameBatterType, FilterGamePitcherType } from "@customTypes/boxScore";
 import { gameBatterHeaders, gamePitcherHeaders } from "@data/gameHeaders";
 import { filterGameBatterData, filterGamePitcherData } from "@utils/filterBoxScoreData";
-import { useEffect } from "react";
+import { useBoxScoreQuery } from "hooks/useBoxScore";
 import { useGameStore } from "store/actions/useGameStore";
 import styled from "styled-components";
 import LocationTitle from "../components/Location/LocationTitle";
@@ -18,20 +18,15 @@ const ArticleWrapper = styled.article`
 `;
 
 const BoxScore = () => {
-  const fetchDaySchedule = useGameStore((state) => state.fetchDaySchedule);
   const hBatters = useGameStore((state) => state.hBatters);
   const hPitchers = useGameStore((state) => state.hPitchers);
   const vBatters = useGameStore((state) => state.vBatters);
   const vPitchers = useGameStore((state) => state.vPitchers);
   const schedule = useGameStore((state) => state.schedule);
 
-  // 처음 페이지 방문시
-  useEffect(() => {
-    if (!schedule) {
-      fetchDaySchedule();
-    }
-  }, []);
-  if (!schedule) return <></>;
+  const { isError, isLoading } = useBoxScoreQuery();
+
+  if (isError || isLoading) return <></>;
 
   const filteredHBatters: FilterGameBatterType[] | undefined = hBatters?.map(filterGameBatterData);
   const filteredHPitchers: FilterGamePitcherType[] | undefined = hPitchers?.map(filterGamePitcherData);

--- a/src/pages/BoxScore.tsx
+++ b/src/pages/BoxScore.tsx
@@ -23,10 +23,11 @@ const BoxScore = () => {
   const vBatters = useGameStore((state) => state.vBatters);
   const vPitchers = useGameStore((state) => state.vPitchers);
   const schedule = useGameStore((state) => state.schedule);
+  const daySchedule = useGameStore((state) => state.daySchedule);
 
-  const { isError, isLoading } = useBoxScoreQuery();
+  const { isError } = useBoxScoreQuery(daySchedule?.gameDate, daySchedule?.gmkey);
 
-  if (isError || isLoading) return <></>;
+  if (isError) return <></>;
 
   const filteredHBatters: FilterGameBatterType[] | undefined = hBatters?.map(filterGameBatterData);
   const filteredHPitchers: FilterGamePitcherType[] | undefined = hPitchers?.map(filterGamePitcherData);
@@ -42,25 +43,25 @@ const BoxScore = () => {
           <MainTable />
         </ArticleWrapper>
         <ArticleWrapper>
-          <LocationTitle title={`${schedule?.current.visit} 타자 기록`} />
+          <LocationTitle title={`${schedule ? schedule.current.visit : ""} 타자 기록`} />
           {filteredVBatters && (
             <PlayerTable<FilterGameBatterType> resData={filteredVBatters} headers={gameBatterHeaders} />
           )}
         </ArticleWrapper>
         <ArticleWrapper>
-          <LocationTitle title={`${schedule?.current.home} 타자 기록`} />
+          <LocationTitle title={`${schedule ? schedule.current.home : ""} 타자 기록`} />
           {filteredHBatters && (
             <PlayerTable<FilterGameBatterType> resData={filteredHBatters} headers={gameBatterHeaders} />
           )}
         </ArticleWrapper>
         <ArticleWrapper>
-          <LocationTitle title={`${schedule?.current.visit} 투수 기록`} />
+          <LocationTitle title={`${schedule ? schedule.current.visit : ""} 투수 기록`} />
           {filteredVPitchers && (
             <PlayerTable<FilterGamePitcherType> resData={filteredVPitchers} headers={gamePitcherHeaders} />
           )}
         </ArticleWrapper>
         <ArticleWrapper>
-          <LocationTitle title={`${schedule?.current.home} 투수 기록`} />
+          <LocationTitle title={`${schedule ? schedule.current.home : ""} 투수 기록`} />
           {filteredHPitchers && (
             <PlayerTable<FilterGamePitcherType> resData={filteredHPitchers} headers={gamePitcherHeaders} />
           )}

--- a/src/pages/BoxScore.tsx
+++ b/src/pages/BoxScore.tsx
@@ -25,9 +25,9 @@ const BoxScore = () => {
   const schedule = useGameStore((state) => state.schedule);
   const daySchedule = useGameStore((state) => state.daySchedule);
 
-  const { isError } = useBoxScoreQuery(daySchedule?.gameDate, daySchedule?.gmkey);
+  const { isError, isLoading } = useBoxScoreQuery(daySchedule?.gameDate, daySchedule?.gmkey);
 
-  if (isError) return <></>;
+  if (isError || (!schedule && isLoading)) return <></>;
 
   const filteredHBatters: FilterGameBatterType[] | undefined = hBatters?.map(filterGameBatterData);
   const filteredHPitchers: FilterGamePitcherType[] | undefined = hPitchers?.map(filterGamePitcherData);

--- a/src/store/actions/useGameStore.ts
+++ b/src/store/actions/useGameStore.ts
@@ -10,7 +10,7 @@ export const useGameStore = create<GameStoreType>((set) => ({
   hPitchers: null,
   vBatters: null,
   vPitchers: null,
-  setDaySchedule: (data) => set({ daySchedule: data }),
+  setDaySchedule: (data) => set({ daySchedule: { gameDate: data.gameDate, gmkey: data.gmkey } }),
   setBoxScore: (data) =>
     set({
       schedule: data.schedule,

--- a/src/store/actions/useGameStore.ts
+++ b/src/store/actions/useGameStore.ts
@@ -1,4 +1,3 @@
-import { api } from "api/api";
 import { GameStoreType } from "store/types/gameStore";
 import { create } from "zustand";
 
@@ -11,35 +10,15 @@ export const useGameStore = create<GameStoreType>((set) => ({
   hPitchers: null,
   vBatters: null,
   vPitchers: null,
-  fetchDaySchedule: async () => {
-    const data = await api("game/recentGames");
-    data && set({ daySchedule: data.data.current });
-
-    const resData = await api(`game/boxscore`);
-
-    resData &&
-      set({
-        schedule: resData.data.schedule,
-        scoreBoard: resData.data.scoreboard,
-        etcGames: resData.data.etcgames,
-        hBatters: resData.data.hbatters,
-        hPitchers: resData.data.hpitchers,
-        vBatters: resData.data.vbatters,
-        vPitchers: resData.data.vpitchers,
-      });
-  },
-  fetchBoxScore: async (gameData: string, gmkey: string) => {
-    const data = await api(`game/boxscore?gameDate=${gameData}&gmkey=${gmkey}`);
-
-    data &&
-      set({
-        schedule: data.data.schedule,
-        scoreBoard: data.data.scoreboard,
-        etcGames: data.data.etcgames,
-        hBatters: data.data.hbatters,
-        hPitchers: data.data.hpitchers,
-        vBatters: data.data.vbatters,
-        vPitchers: data.data.vpitchers,
-      });
-  },
+  setDaySchedule: (data) => set({ daySchedule: data }),
+  setBoxScore: (data) =>
+    set({
+      schedule: data.schedule,
+      scoreBoard: data.scoreboard,
+      etcGames: data.etcgames,
+      hBatters: data.hbatters,
+      hPitchers: data.hpitchers,
+      vBatters: data.vbatters,
+      vPitchers: data.vpitchers,
+    }),
 }));

--- a/src/store/types/gameStore.d.ts
+++ b/src/store/types/gameStore.d.ts
@@ -16,6 +16,6 @@ export type GameStoreType = {
   hPitchers: GamePitchersType[] | null;
   vBatters: GameBattersType[] | null;
   vPitchers: GamePitchersType[] | null;
-  fetchDaySchedule: () => void;
-  fetchBoxScore: (gameData: string, gmkey: string) => void;
+  setDaySchedule: (data) => void;
+  setBoxScore: (data) => void;
 };

--- a/src/store/types/gameStore.d.ts
+++ b/src/store/types/gameStore.d.ts
@@ -1,14 +1,7 @@
-import {
-  DayScheduleType,
-  EtcGames,
-  GameBattersType,
-  GamePitchersType,
-  ScheduleListType,
-  ScoreboardType,
-} from "@customTypes/boxScore";
+import { EtcGames, GameBattersType, GamePitchersType, ScheduleListType, ScoreboardType } from "@customTypes/boxScore";
 
 export type GameStoreType = {
-  daySchedule: DayScheduleType | null;
+  daySchedule: { gameDate: string; gmkey: string } | null;
   schedule: ScheduleListType | null;
   scoreBoard: ScoreboardType[] | null;
   etcGames: EtcGames[] | null;


### PR DESCRIPTION
## #️⃣ 연관된 이슈

> #120

## 📝 작업 내용

> Box Score부분 데이터 패칭 tanstack query 적용

### 스크린샷 (선택)
![image](https://github.com/user-attachments/assets/f5645412-6039-426f-97a6-c9a5e5f93a4a)
최적화 진행 후
![image](https://github.com/user-attachments/assets/adeda268-1e5f-4bcd-9946-bfd322f4cb72)

## 💬 리뷰 요구사항(선택)

새로 고침 하면 데이터 저장이 안되어있습니다. 다만 다른 메뉴를 갔다가 다시 돌아오면 데이터 저장이 되어있어 최근 본 경기페이지로 넘어갑니다. 이 부분에 대해서 새로 고침할때 저번에 구현했던 방법처럼 url에 데이터 값을 저장해서 보여줄지 의논해 봐야할 것 같습니다.
