### PR TITLE
game-경기일정 마크업&스타일링

### DIFF
--- a/src/components/Game/Schedule/Broadcast.tsx
+++ b/src/components/Game/Schedule/Broadcast.tsx
@@ -1,0 +1,18 @@
+import styled from "styled-components";
+import BroadcastList from "./Broadcast/BroadcastList";
+
+const BroadcastStyle = styled.ul`
+  width: 100%;
+  display: flex;
+  flex-direction: column;
+  gap: 5px;
+`;
+
+const Broadcast = () => {
+  return (
+    <BroadcastStyle>
+      <BroadcastList />
+    </BroadcastStyle>
+  );
+};
+export default Broadcast;

--- a/src/components/Game/Schedule/Broadcast/BroadcastItem.tsx
+++ b/src/components/Game/Schedule/Broadcast/BroadcastItem.tsx
@@ -1,0 +1,183 @@
+import styled from "styled-components";
+
+interface BroadcastItemProps {
+  tag: string;
+}
+
+const BroadcastItemStyle = styled.p`
+  font-size: 13px;
+  color: #222;
+  font-weight: 300;
+  line-height: 1.3;
+
+  & > span {
+    color: #666;
+
+    &::after {
+      display: inline;
+      content: ", ";
+    }
+  }
+
+  &:last-child {
+    & > span {
+      &::after {
+        display: none;
+      }
+    }
+  }
+`;
+
+const BroadcastItem = ({ tag }: BroadcastItemProps) => {
+  const broadcastItemList = [
+    {
+      tv: [
+        {
+          abb: "K-2T",
+          name: "KBS 2TV",
+        },
+        {
+          abb: "M-T",
+          name: "MBC TV",
+        },
+        {
+          abb: "S-T",
+          name: "SBS TV",
+        },
+        {
+          abb: "KN-T",
+          name: "KBS N SPORTS",
+        },
+        {
+          abb: "MS-T",
+          name: "MBC SPORTS PLUS",
+        },
+        {
+          abb: "SS-T",
+          name: "SBS SPORTS",
+        },
+        {
+          abb: "SPOTV+",
+          name: "SPOTV PLUS",
+        },
+        {
+          abb: "SKY-T",
+          name: "SKY SPORTS",
+        },
+      ],
+      cmb: [
+        {
+          abb: "D-CMB",
+          name: "대전 CMB",
+        },
+        {
+          abb: "K-CMB",
+          name: "광주 CMB",
+        },
+      ],
+      iptv: [
+        {
+          abb: "SPO-T",
+          name: "SPOTV",
+        },
+        {
+          abb: "SPO-2T",
+          name: "SPOTV2",
+        },
+        {
+          abb: "IB-T",
+          name: "IB SPORTS",
+        },
+      ],
+      radio: [
+        {
+          abb: "K-2R",
+          name: "KBS 2라디오",
+        },
+        {
+          abb: "M-R",
+          name: "MBC 라디오",
+        },
+        {
+          abb: "S-R",
+          name: "SBS 라디오",
+        },
+        {
+          abb: "DK-R",
+          name: "대전 KBS 라디오",
+        },
+        {
+          abb: "TM-R",
+          name: "대구 MBC 라디오",
+        },
+        {
+          abb: "PM-R",
+          name: "부산 MBC 라디오",
+        },
+        {
+          abb: "DM-R",
+          name: "대전 MBC 라디오",
+        },
+        {
+          abb: "KM-R",
+          name: "광주 MBC 라디오",
+        },
+        {
+          abb: "GM-R",
+          name: "MBC 경남 라디오",
+        },
+        {
+          abb: "T-R",
+          name: "TBC 라디오",
+        },
+        {
+          abb: "TJ-R",
+          name: "TJB 라디오",
+        },
+        {
+          abb: "KNN-R",
+          name: "KNN 라디오",
+        },
+        {
+          abb: "KBC-R",
+          name: "KBC 라디오",
+        },
+      ],
+    },
+  ];
+
+  return (
+    <>
+      {broadcastItemList.map((item) =>
+        tag === "TV"
+          ? item.tv.map((el, index) => (
+              <BroadcastItemStyle key={index}>
+                {el.abb}
+                <span>{`(${el.name})`}</span>
+              </BroadcastItemStyle>
+            ))
+          : tag === "CMB"
+            ? item.cmb.map((el, index) => (
+                <BroadcastItemStyle key={index}>
+                  {el.abb}
+                  <span>{`(${el.name})`}</span>
+                </BroadcastItemStyle>
+              ))
+            : tag === "IPTV"
+              ? item.iptv.map((el, index) => (
+                  <BroadcastItemStyle key={index}>
+                    {el.abb}
+                    <span>{`(${el.name})`}</span>
+                  </BroadcastItemStyle>
+                ))
+              : item.radio.map((el, index) => (
+                  <BroadcastItemStyle key={index}>
+                    {el.abb}
+                    <span>{`(${el.name})`}</span>
+                  </BroadcastItemStyle>
+                ))
+      )}
+    </>
+  );
+};
+export default BroadcastItem;

--- a/src/components/Game/Schedule/Broadcast/BroadcastList.tsx
+++ b/src/components/Game/Schedule/Broadcast/BroadcastList.tsx
@@ -1,0 +1,32 @@
+import styled from "styled-components";
+import BroadcastItem from "./BroadcastItem";
+import Tag from "./Tag";
+
+const BroadcastListStyle = styled.li`
+  display: flex;
+  align-items: baseline;
+
+  & > div {
+    width: 100%;
+    display: flex;
+    flex-wrap: wrap;
+    gap: 5px;
+  }
+`;
+
+const BroadcastList = () => {
+  const tagList = ["TV", "CMB", "IPTV", "RADIO"];
+  return (
+    <>
+      {tagList.map((tag, index) => (
+        <BroadcastListStyle>
+          <Tag tag={tag} />
+          <div key={index}>
+            <BroadcastItem tag={tag} />
+          </div>
+        </BroadcastListStyle>
+      ))}
+    </>
+  );
+};
+export default BroadcastList;

--- a/src/components/Game/Schedule/Broadcast/Tag.tsx
+++ b/src/components/Game/Schedule/Broadcast/Tag.tsx
@@ -1,0 +1,23 @@
+import styled from "styled-components";
+
+interface TagProps {
+  tag: string;
+}
+
+const TagStyle = styled.span`
+  width: 100%;
+  max-width: 46px;
+  font-size: 12px;
+  background-color: #494949;
+  color: #fff;
+  font-weight: 300;
+  border-radius: 5px;
+  padding: 5px;
+  margin-right: 10px;
+  text-align: center;
+`;
+
+const Tag = ({ tag }: TagProps) => {
+  return <TagStyle>{tag}</TagStyle>;
+};
+export default Tag;

--- a/src/components/Game/Schedule/Calendar.tsx
+++ b/src/components/Game/Schedule/Calendar.tsx
@@ -1,0 +1,44 @@
+import styled from "styled-components";
+import Body from "./Calendar/Body";
+import Header from "./Calendar/Header";
+import Tab from "./Calendar/Tab";
+
+const CalendarStyle = styled.div`
+  width: 100%;
+
+  & > div:first-child {
+    width: 100%;
+    display: flex;
+    align-items: center;
+  }
+
+  & > div:last-child {
+    width: 100%;
+    display: flex;
+    flex-direction: column;
+    align-items: center;
+
+    & > span {
+      font-size: 14px;
+      color: #222;
+      font-weight: 300;
+      align-self: flex-end;
+    }
+  }
+`;
+
+const Calendar = () => {
+  return (
+    <CalendarStyle>
+      <div>
+        <Tab />
+        <Header />
+      </div>
+      <div>
+        <Body />
+        <span>* 경기 일정은 사정에 따라 변동될 수있습니다.</span>
+      </div>
+    </CalendarStyle>
+  );
+};
+export default Calendar;

--- a/src/components/Game/Schedule/Calendar/Body.tsx
+++ b/src/components/Game/Schedule/Calendar/Body.tsx
@@ -1,0 +1,17 @@
+import styled from "styled-components";
+
+const BodyStyle = styled.div`
+  width: 100%;
+  margin: 20px 0 15px 0;
+  border-top: 2px solid #222;
+  border-bottom: 2px solid #222;
+`;
+
+const Body = () => {
+  return (
+    <BodyStyle>
+      <h1>Calendar Body</h1>
+    </BodyStyle>
+  );
+};
+export default Body;

--- a/src/components/Game/Schedule/Calendar/Header.tsx
+++ b/src/components/Game/Schedule/Calendar/Header.tsx
@@ -1,0 +1,14 @@
+import styled from "styled-components";
+
+const HeaderStyle = styled.div`
+  width: 100%;
+`;
+
+const Header = () => {
+  return (
+    <HeaderStyle>
+      <h1>Calendar Header</h1>
+    </HeaderStyle>
+  );
+};
+export default Header;

--- a/src/components/Game/Schedule/Calendar/Tab.tsx
+++ b/src/components/Game/Schedule/Calendar/Tab.tsx
@@ -1,0 +1,34 @@
+import styled from "styled-components";
+
+const TabStyle = styled.ul`
+  width: 100%;
+  max-width: 240px;
+  display: flex;
+  justify-content: center;
+  align-items: center;
+
+  & > li {
+    width: 100%;
+    max-width: 120px;
+    padding: 8px 20px;
+    color: #222;
+    font-weight: 300;
+    font-size: 14px;
+    text-align: center;
+  }
+
+  & > li:first-child {
+    background-color: #ec0a0b;
+    color: #fff;
+  }
+`;
+
+const Tab = () => {
+  return (
+    <TabStyle>
+      <li>kt wiz 경기</li>
+      <li>전체 리그</li>
+    </TabStyle>
+  );
+};
+export default Tab;

--- a/src/components/Game/Schedule/Common/Button.tsx
+++ b/src/components/Game/Schedule/Common/Button.tsx
@@ -1,0 +1,26 @@
+import { Link } from "react-router-dom";
+import styled from "styled-components";
+
+interface ButtonProps {
+  to: string;
+}
+
+const ButtonStyle = styled(Link)`
+  display: flex;
+  justify-content: center;
+  align-items: center;
+  max-width: 90px;
+  min-height: 28px;
+  padding: 5px 15px;
+  margin-top: 8px;
+  border-radius: 20px;
+  background-color: #909090;
+  color: #fff;
+  font-size: 14px;
+  font-weight: 300;
+`;
+
+const Button = ({ to }: ButtonProps) => {
+  return <ButtonStyle to={to}>경기 정보</ButtonStyle>;
+};
+export default Button;

--- a/src/components/Game/Schedule/Common/Date.tsx
+++ b/src/components/Game/Schedule/Common/Date.tsx
@@ -1,0 +1,21 @@
+import styled from "styled-components";
+
+interface DateProps {
+  date: string;
+  $bgColor?: string;
+}
+
+const DateStyle = styled.span<{ $bgColor?: string }>`
+  max-width: 120px;
+  min-height: 28px;
+  padding: 5px 25px;
+  border-radius: 20px;
+  background-color: ${(props) => props.$bgColor || "#343434"};
+  color: #fff;
+  font-weight: 300;
+`;
+
+const Date = ({ date, $bgColor }: DateProps) => {
+  return <DateStyle $bgColor={$bgColor}>{date}</DateStyle>;
+};
+export default Date;

--- a/src/components/Game/Schedule/Common/Logo.tsx
+++ b/src/components/Game/Schedule/Common/Logo.tsx
@@ -1,0 +1,15 @@
+import styled from "styled-components";
+
+interface LogoProps {
+  src: string;
+}
+
+const LogoStyle = styled.img`
+  width: 100%;
+  max-width: 56px;
+`;
+
+const Logo = ({ src }: LogoProps) => {
+  return <LogoStyle src={src} alt="logo" />;
+};
+export default Logo;

--- a/src/components/Game/Schedule/Common/Score.tsx
+++ b/src/components/Game/Schedule/Common/Score.tsx
@@ -1,0 +1,24 @@
+import styled from "styled-components";
+
+interface ScoreProps {
+  visitScore: number;
+  homeScore: number;
+}
+
+const ScoreStyle = styled.div`
+  margin: 22px 0;
+
+  & > span {
+    font-size: 24px;
+    font-weight: 300;
+  }
+`;
+
+const Score = ({ visitScore, homeScore }: ScoreProps) => {
+  return (
+    <ScoreStyle>
+      <span>{`${visitScore} : ${homeScore}`}</span>
+    </ScoreStyle>
+  );
+};
+export default Score;

--- a/src/components/Game/Schedule/Common/Text.tsx
+++ b/src/components/Game/Schedule/Common/Text.tsx
@@ -1,0 +1,22 @@
+import styled from "styled-components";
+
+interface TextProps {
+  text: string;
+  $color?: string;
+  $fontSize?: string;
+}
+
+const TextStyle = styled.span<{ $color?: string; $fontSize?: string }>`
+  color: ${(props) => props.$color || "#000"};
+  font-size: ${(props) => props.$fontSize || "14px"};
+  font-weight: 300;
+`;
+
+const Text = ({ text, $color, $fontSize }: TextProps) => {
+  return (
+    <TextStyle $color={$color} $fontSize={$fontSize}>
+      {text}
+    </TextStyle>
+  );
+};
+export default Text;

--- a/src/components/Game/Schedule/HomeTeam.tsx
+++ b/src/components/Game/Schedule/HomeTeam.tsx
@@ -1,0 +1,24 @@
+import styled from "styled-components";
+import Logo from "./Common/Logo";
+import Text from "./Common/Text";
+
+const HomeTeamStyle = styled.div`
+  display: flex;
+  flex-direction: column;
+  justify-content: center;
+  align-items: center;
+  gap: 10px;
+`;
+
+const HomeTeam = () => {
+  return (
+    <HomeTeamStyle>
+      <Logo src="" />
+      <div>
+        <Text text="KT 위즈" />
+        <Text text="L : 고영표" $color="#666" />
+      </div>
+    </HomeTeamStyle>
+  );
+};
+export default HomeTeam;

--- a/src/components/Game/Schedule/ScheduleItem.tsx
+++ b/src/components/Game/Schedule/ScheduleItem.tsx
@@ -1,0 +1,61 @@
+import styled from "styled-components";
+import Button from "./Common/Button";
+import Date from "./Common/Date";
+import Score from "./Common/Score";
+import Text from "./Common/Text";
+import HomeTeam from "./HomeTeam";
+import VisitTeam from "./VisitTeam";
+
+const ScheduleItemStyle = styled.li`
+  position: relative;
+  width: 100%;
+  display: flex;
+  flex-direction: column;
+  justify-content: center;
+  align-items: center;
+  padding: 20px;
+  border: 1px solid #d2d2d2;
+  gap: 10px;
+
+  div {
+    width: 100%;
+    display: flex;
+    justify-content: space-around;
+    align-items: center;
+
+    & > div {
+      display: flex;
+      flex-direction: column;
+      justify-content: center;
+      align-items: center;
+      gap: 5px;
+    }
+  }
+
+  &:nth-child(2) {
+    z-index: 1;
+    width: 100%;
+    min-width: 400px;
+    min-height: 226px;
+    height: 100%;
+    box-shadow: 0 3px 7px 0 rgba(0, 0, 0, 0.24);
+  }
+`;
+
+const ScheduleItem = () => {
+  return (
+    <ScheduleItemStyle>
+      <Date date="2024.9.21" />
+      <div>
+        <VisitTeam />
+        <div>
+          <Score visitScore={4} homeScore={1} />
+          <Text text="패" $color="#ec0a0b" />
+          <Button to="#" />
+        </div>
+        <HomeTeam />
+      </div>
+    </ScheduleItemStyle>
+  );
+};
+export default ScheduleItem;

--- a/src/components/Game/Schedule/ScheduleList.tsx
+++ b/src/components/Game/Schedule/ScheduleList.tsx
@@ -1,0 +1,21 @@
+import styled from "styled-components";
+import ScheduleItem from "./ScheduleItem";
+
+const ScheduleListStyle = styled.ul`
+  width: 100%;
+  display: flex;
+  justify-content: center;
+  align-items: center;
+  padding: 38px 0;
+`;
+
+const ScheduleList = () => {
+  return (
+    <ScheduleListStyle>
+      <ScheduleItem />
+      <ScheduleItem />
+      <ScheduleItem />
+    </ScheduleListStyle>
+  );
+};
+export default ScheduleList;

--- a/src/components/Game/Schedule/VisitTeam.tsx
+++ b/src/components/Game/Schedule/VisitTeam.tsx
@@ -1,0 +1,24 @@
+import styled from "styled-components";
+import Logo from "./Common/Logo";
+import Text from "./Common/Text";
+
+const VisitTeamStyle = styled.div`
+  display: flex;
+  flex-direction: column;
+  justify-content: center;
+  align-items: center;
+  gap: 10px;
+`;
+
+const VisitTeam = () => {
+  return (
+    <VisitTeamStyle>
+      <Logo src="" />
+      <div>
+        <Text text="SSG 랜더스" />
+        <Text text="W : 엘리아스" $color="#666" />
+      </div>
+    </VisitTeamStyle>
+  );
+};
+export default VisitTeam;

--- a/src/pages/Schedule.tsx
+++ b/src/pages/Schedule.tsx
@@ -1,0 +1,24 @@
+import Broadcast from "@components/Game/Schedule/Broadcast";
+import Calendar from "@components/Game/Schedule/Calendar";
+import ScheduleList from "@components/Game/Schedule/ScheduleList";
+import styled from "styled-components";
+
+const ScheduleStyle = styled.section`
+  width: 100%;
+  display: flex;
+  flex-direction: column;
+  justify-content: center;
+  align-items: center;
+  gap: 40px;
+`;
+
+const Schedule = () => {
+  return (
+    <ScheduleStyle>
+      <ScheduleList />
+      <Calendar />
+      <Broadcast />
+    </ScheduleStyle>
+  );
+};
+export default Schedule;

--- a/src/router/index.tsx
+++ b/src/router/index.tsx
@@ -23,6 +23,7 @@ import PitcherDetail from "@pages/PitcherDetail";
 import Policy from "@pages/Policy";
 import Press from "@pages/Press";
 import PressDetail from "@pages/PressDetail";
+import Schedule from "@pages/Schedule";
 import Store from "@pages/Store";
 import TeamRanking from "@pages/TeamRanking";
 import WatchPoint from "@pages/WatchPoint";
@@ -130,7 +131,7 @@ export const router = createBrowserRouter([
         children: [
           {
             path: "schedule",
-            element: "정규리그 component",
+            element: <Schedule />,
           },
           {
             path: "boxscore",


### PR DESCRIPTION
## #️⃣ 연관된 이슈

> #117

## 📝 작업 내용

> - [x] 경기일정 페이지 마크업&스타일링

### 스크린샷 (선택)
![image](https://github.com/user-attachments/assets/fa9d80dd-20ae-4587-b3da-ea6e76e9e79d)

## 💬 리뷰 요구사항(선택)

> 캘린더 라이브러리 적용 예정입니다. (캘린더 컨트롤러-헤더, 캘린더 바디)
> 로고는 데이터 패칭전이어서 alt 메세지로 대체하여 뜨고있습니다.
> 일부 스타일링(로고이미지, 컬러, 탭메뉴 등)은 데이터 패칭하면서 수정하겠습니다.
