### PR TITLE
게임-팀순위 테이블 api연결

### DIFF
--- a/src/components/Game/TeamRanking/RecordBatter.tsx
+++ b/src/components/Game/TeamRanking/RecordBatter.tsx
@@ -1,8 +1,9 @@
 import ArticleTitle from "@components/common/ArticleTitle";
 import Table from "@components/common/Table";
 import { TBattingRank } from "@customTypes/teamRank";
-import dummy from "@data/game/rankBatting.json";
 import { filterData } from "@utils/filterData";
+import { api } from "api/api";
+import { useEffect, useState } from "react";
 
 export const teamRankingHeaders: [string, string][] = [
   ["teamName", "팀명"],
@@ -24,11 +25,23 @@ export const teamRankingHeaders: [string, string][] = [
   ["hra", "타율"],
 ];
 const RecordBatter = () => {
-  const data = dummy.data.list.map((data) => filterData(data, teamRankingHeaders)) as TBattingRank[];
+  const [batters, setBatters] = useState<TBattingRank[]>([]);
+
+  useEffect(() => {
+    const fetchData = async () => {
+      const { data } = await api("game/rank/batting");
+      const ranking = data?.list?.map((team: TBattingRank) => filterData(team, teamRankingHeaders));
+      setBatters(ranking);
+    };
+    fetchData();
+  }, []);
+
   return (
     <article>
       <ArticleTitle title="2024 시즌 팀 타자 기록" />
-      <Table<TBattingRank> resData={data} headers={teamRankingHeaders.map((item) => item[1])} />
+      {batters.length > 0 && (
+        <Table<TBattingRank> resData={batters} headers={teamRankingHeaders.map((item) => item[1])} />
+      )}
     </article>
   );
 };

--- a/src/components/Game/TeamRanking/RecordPicher.tsx
+++ b/src/components/Game/TeamRanking/RecordPicher.tsx
@@ -1,8 +1,9 @@
 import ArticleTitle from "@components/common/ArticleTitle";
 import Table from "@components/common/Table";
 import { TPicheringRank } from "@customTypes/teamRank";
-import dummy from "@data/game/rankPitching.json";
 import { filterData } from "@utils/filterData";
+import { api } from "api/api";
+import { useEffect, useState } from "react";
 
 export const teamRankingHeaders: [string, string][] = [
   ["teamName", "팀명"],
@@ -22,12 +23,23 @@ export const teamRankingHeaders: [string, string][] = [
   ["qs", "QS"],
 ];
 const RecordPicher = () => {
-  const data = dummy.data.list.map((data) => filterData(data, teamRankingHeaders)) as TPicheringRank[];
+  const [pitchers, setPitchers] = useState<TPicheringRank[]>([]);
+
+  useEffect(() => {
+    const fetchData = async () => {
+      const { data } = await api("game/rank/pitching");
+      const ranking = data?.list?.map((team: TPicheringRank) => filterData(team, teamRankingHeaders));
+      setPitchers(ranking);
+    };
+    fetchData();
+  }, []);
 
   return (
     <article>
       <ArticleTitle title="2024 시즌 팀 투수 기록" />
-      <Table<TPicheringRank> resData={data} headers={teamRankingHeaders.map((item) => item[1])} />
+      {pitchers.length > 0 && (
+        <Table<TPicheringRank> resData={pitchers} headers={teamRankingHeaders.map((item) => item[1])} />
+      )}
     </article>
   );
 };

--- a/src/components/Game/TeamRanking/RecordTeam.tsx
+++ b/src/components/Game/TeamRanking/RecordTeam.tsx
@@ -1,8 +1,9 @@
 import ArticleTitle from "@components/common/ArticleTitle";
 import Table from "@components/common/Table";
 import { TTemaRank } from "@customTypes/teamRank";
-import dummy from "@data/game/teamRankByYear.json";
 import { filterData } from "@utils/filterData";
+import { api } from "api/api";
+import { useEffect, useState } from "react";
 
 export const teamRankingHeaders: [string, string][] = [
   ["rank", "순위"],
@@ -42,12 +43,20 @@ export const teamRankHeaders = [
 ];
 
 const RecordTeam = () => {
-  const data = dummy.data.list.map((data) => filterData(data, teamRankingHeaders)) as TTemaRank[];
+  const [teams, setTeams] = useState<TTemaRank[]>([]);
 
+  useEffect(() => {
+    const fetchData = async () => {
+      const { data } = await api("game/teamrankbyyear");
+      const ranking = data?.list?.map((team: TTemaRank) => filterData(team, teamRankingHeaders));
+      setTeams(ranking);
+    };
+    fetchData();
+  }, []);
   return (
     <article>
       <ArticleTitle title="2024 시즌 팀 기록" />
-      <Table<TTemaRank> resData={data} headers={teamRankingHeaders.map((item) => item[1])} />
+      {teams.length > 0 && <Table<TTemaRank> resData={teams} headers={teamRankingHeaders.map((item) => item[1])} />}
     </article>
   );
 };

--- a/src/components/Game/TeamRanking/WinLose.tsx
+++ b/src/components/Game/TeamRanking/WinLose.tsx
@@ -1,7 +1,21 @@
 import ArticleTitle from "@components/common/ArticleTitle";
+import { TTeamVS } from "@customTypes/teamRank";
+import { getVSinfo } from "@utils/filterData";
+import { api } from "api/api";
+import { useEffect, useState } from "react";
 import styled from "styled-components";
-
-export const teamRankingHeaders = ["KT", "삼성", "두산", "LG", "키움", "롯데", "SSG", "NC", "KIA", "한화"];
+export const teamRankingHeaders = [
+  ["KT", "KT"],
+  ["SS", "삼성"],
+  ["OB", "두산"],
+  ["LG", "LG"],
+  ["WO", "키움"],
+  ["LT", "롯데"],
+  ["SK", "SSG"],
+  ["NC", "NC"],
+  ["HT", "KIA"],
+  ["HH", "한화"],
+];
 
 const StyledTable = styled.table`
   width: 100%;
@@ -11,7 +25,7 @@ const StyledTable = styled.table`
   border: 1px solid #cfcfcf;
   border-top: 2px solid #ec0a0b;
 `;
-const StyledTr = styled.tr`
+const StyledTr = styled.tr<{ $isActive?: boolean }>`
   & > th,
   td {
     width: 100px;
@@ -30,17 +44,28 @@ const StyledTr = styled.tr`
   & > td {
     font-size: 12px;
     border-top: 1px solid #cfcfcf;
-    color: #5b5a5a;
-    background-color: #fff;
+    color: ${({ $isActive }) => ($isActive ? "#ec0a0b" : "#5b5a5a")};
+    background-color: ${({ $isActive }) => ($isActive ? "#fff5f7" : "#fff")};
     padding: 8px 0;
   }
-
-  &:nth-child(1) > td {
-    color: #ec0a0b;
+  & > th:nth-child(2),
+  td:nth-child(2) {
     background-color: #fff5f7;
+    color: #ec0a0b;
   }
 `;
+
 const WinLose = () => {
+  const [teamVs, setTeamVs] = useState<TTeamVS[]>([]);
+
+  useEffect(() => {
+    const fetchData = async () => {
+      const { data } = await api("game/rank/teamvs");
+      setTeamVs(data?.list);
+    };
+    fetchData();
+  }, []);
+
   return (
     <article>
       <ArticleTitle title="2024 시즌 팀 간 승패표" />
@@ -52,18 +77,26 @@ const WinLose = () => {
               <br />
               (승-패-무)
             </th>
-            {teamRankingHeaders.map((name, colIndex) => (
-              <th key={colIndex}>{name}</th>
+            {teamRankingHeaders.map((team, colIndex) => (
+              <th key={colIndex}>{team[1]}</th>
             ))}
           </StyledTr>
         </thead>
         <tbody>
           {teamRankingHeaders.map((row, rowIndex) => (
-            <StyledTr key={rowIndex}>
-              <td>{row}</td>
-              {teamRankingHeaders.map((col, colIndex) => (
-                <td key={colIndex}>{row === col ? "■" : " "}</td>
-              ))}
+            <StyledTr key={rowIndex} $isActive={rowIndex === 0}>
+              <td>{row[1]}</td>
+              {teamVs &&
+                teamRankingHeaders.map((col, colIndex) => {
+                  let result;
+                  if (rowIndex === colIndex) {
+                    result = "■";
+                  } else {
+                    const record = getVSinfo(teamVs, row[1], col[0]);
+                    result = `${record[0]}-${record[1]}-${record[2]}`;
+                  }
+                  return <td key={colIndex}>{result}</td>;
+                })}
             </StyledTr>
           ))}
         </tbody>

--- a/src/data/game/rankTeamVs.json
+++ b/src/data/game/rankTeamVs.json
@@ -23,7 +23,703 @@
         "teamCode": "HH",
         "teamName": "한화",
         "vsTeamCode": "LG",
+        "win": 8
+      },
+      {
+        "drawn": 0,
+        "lose": 9,
+        "teamCode": "HH",
+        "teamName": "한화",
+        "vsTeamCode": "LT",
         "win": 7
+      },
+      {
+        "drawn": 2,
+        "lose": 9,
+        "teamCode": "HH",
+        "teamName": "한화",
+        "vsTeamCode": "NC",
+        "win": 4
+      },
+      {
+        "drawn": 0,
+        "lose": 6,
+        "teamCode": "HH",
+        "teamName": "한화",
+        "vsTeamCode": "OB",
+        "win": 10
+      },
+      {
+        "drawn": 0,
+        "lose": 5,
+        "teamCode": "HH",
+        "teamName": "한화",
+        "vsTeamCode": "SK",
+        "win": 10
+      },
+      {
+        "drawn": 0,
+        "lose": 10,
+        "teamCode": "HH",
+        "teamName": "한화",
+        "vsTeamCode": "SS",
+        "win": 6
+      },
+      {
+        "drawn": 0,
+        "lose": 10,
+        "teamCode": "HH",
+        "teamName": "한화",
+        "vsTeamCode": "WO",
+        "win": 6
+      },
+      {
+        "drawn": 0,
+        "lose": 4,
+        "teamCode": "HT",
+        "teamName": "KIA",
+        "vsTeamCode": "HH",
+        "win": 11
+      },
+      {
+        "drawn": 0,
+        "lose": 7,
+        "teamCode": "HT",
+        "teamName": "KIA",
+        "vsTeamCode": "KT",
+        "win": 9
+      },
+      {
+        "drawn": 0,
+        "lose": 3,
+        "teamCode": "HT",
+        "teamName": "KIA",
+        "vsTeamCode": "LG",
+        "win": 13
+      },
+      {
+        "drawn": 1,
+        "lose": 8,
+        "teamCode": "HT",
+        "teamName": "KIA",
+        "vsTeamCode": "LT",
+        "win": 6
+      },
+      {
+        "drawn": 0,
+        "lose": 4,
+        "teamCode": "HT",
+        "teamName": "KIA",
+        "vsTeamCode": "NC",
+        "win": 11
+      },
+      {
+        "drawn": 1,
+        "lose": 9,
+        "teamCode": "HT",
+        "teamName": "KIA",
+        "vsTeamCode": "OB",
+        "win": 6
+      },
+      {
+        "drawn": 0,
+        "lose": 10,
+        "teamCode": "HT",
+        "teamName": "KIA",
+        "vsTeamCode": "SK",
+        "win": 6
+      },
+      {
+        "drawn": 0,
+        "lose": 4,
+        "teamCode": "HT",
+        "teamName": "KIA",
+        "vsTeamCode": "SS",
+        "win": 12
+      },
+      {
+        "drawn": 0,
+        "lose": 5,
+        "teamCode": "HT",
+        "teamName": "KIA",
+        "vsTeamCode": "WO",
+        "win": 11
+      },
+      {
+        "drawn": 0,
+        "lose": 10,
+        "teamCode": "KT",
+        "teamName": "KT",
+        "vsTeamCode": "HH",
+        "win": 6
+      },
+      {
+        "drawn": 0,
+        "lose": 9,
+        "teamCode": "KT",
+        "teamName": "KT",
+        "vsTeamCode": "HT",
+        "win": 7
+      },
+      {
+        "drawn": 0,
+        "lose": 9,
+        "teamCode": "KT",
+        "teamName": "KT",
+        "vsTeamCode": "LG",
+        "win": 7
+      },
+      {
+        "drawn": 1,
+        "lose": 7,
+        "teamCode": "KT",
+        "teamName": "KT",
+        "vsTeamCode": "LT",
+        "win": 8
+      },
+      {
+        "drawn": 0,
+        "lose": 6,
+        "teamCode": "KT",
+        "teamName": "KT",
+        "vsTeamCode": "NC",
+        "win": 10
+      },
+      {
+        "drawn": 0,
+        "lose": 12,
+        "teamCode": "KT",
+        "teamName": "KT",
+        "vsTeamCode": "OB",
+        "win": 4
+      },
+      {
+        "drawn": 0,
+        "lose": 8,
+        "teamCode": "KT",
+        "teamName": "KT",
+        "vsTeamCode": "SK",
+        "win": 8
+      },
+      {
+        "drawn": 1,
+        "lose": 7,
+        "teamCode": "KT",
+        "teamName": "KT",
+        "vsTeamCode": "SS",
+        "win": 8
+      },
+      {
+        "drawn": 0,
+        "lose": 2,
+        "teamCode": "KT",
+        "teamName": "KT",
+        "vsTeamCode": "WO",
+        "win": 12
+      },
+      {
+        "drawn": 0,
+        "lose": 8,
+        "teamCode": "LG",
+        "teamName": "LG",
+        "vsTeamCode": "HH",
+        "win": 8
+      },
+      {
+        "drawn": 0,
+        "lose": 13,
+        "teamCode": "LG",
+        "teamName": "LG",
+        "vsTeamCode": "HT",
+        "win": 3
+      },
+      {
+        "drawn": 0,
+        "lose": 7,
+        "teamCode": "LG",
+        "teamName": "LG",
+        "vsTeamCode": "KT",
+        "win": 9
+      },
+      {
+        "drawn": 0,
+        "lose": 5,
+        "teamCode": "LG",
+        "teamName": "LG",
+        "vsTeamCode": "LT",
+        "win": 11
+      },
+      {
+        "drawn": 0,
+        "lose": 4,
+        "teamCode": "LG",
+        "teamName": "LG",
+        "vsTeamCode": "NC",
+        "win": 12
+      },
+      {
+        "drawn": 0,
+        "lose": 7,
+        "teamCode": "LG",
+        "teamName": "LG",
+        "vsTeamCode": "OB",
+        "win": 9
+      },
+      {
+        "drawn": 1,
+        "lose": 4,
+        "teamCode": "LG",
+        "teamName": "LG",
+        "vsTeamCode": "SK",
+        "win": 11
+      },
+      {
+        "drawn": 1,
+        "lose": 8,
+        "teamCode": "LG",
+        "teamName": "LG",
+        "vsTeamCode": "SS",
+        "win": 6
+      },
+      {
+        "drawn": 0,
+        "lose": 10,
+        "teamCode": "LG",
+        "teamName": "LG",
+        "vsTeamCode": "WO",
+        "win": 5
+      },
+      {
+        "drawn": 0,
+        "lose": 7,
+        "teamCode": "LT",
+        "teamName": "롯데",
+        "vsTeamCode": "HH",
+        "win": 9
+      },
+      {
+        "drawn": 1,
+        "lose": 6,
+        "teamCode": "LT",
+        "teamName": "롯데",
+        "vsTeamCode": "HT",
+        "win": 8
+      },
+      {
+        "drawn": 1,
+        "lose": 8,
+        "teamCode": "LT",
+        "teamName": "롯데",
+        "vsTeamCode": "KT",
+        "win": 7
+      },
+      {
+        "drawn": 0,
+        "lose": 11,
+        "teamCode": "LT",
+        "teamName": "롯데",
+        "vsTeamCode": "LG",
+        "win": 5
+      },
+      {
+        "drawn": 0,
+        "lose": 7,
+        "teamCode": "LT",
+        "teamName": "롯데",
+        "vsTeamCode": "NC",
+        "win": 7
+      },
+      {
+        "drawn": 1,
+        "lose": 6,
+        "teamCode": "LT",
+        "teamName": "롯데",
+        "vsTeamCode": "OB",
+        "win": 8
+      },
+      {
+        "drawn": 1,
+        "lose": 9,
+        "teamCode": "LT",
+        "teamName": "롯데",
+        "vsTeamCode": "SK",
+        "win": 6
+      },
+      {
+        "drawn": 0,
+        "lose": 10,
+        "teamCode": "LT",
+        "teamName": "롯데",
+        "vsTeamCode": "SS",
+        "win": 6
+      },
+      {
+        "drawn": 0,
+        "lose": 8,
+        "teamCode": "LT",
+        "teamName": "롯데",
+        "vsTeamCode": "WO",
+        "win": 8
+      },
+      {
+        "drawn": 2,
+        "lose": 4,
+        "teamCode": "NC",
+        "teamName": "NC",
+        "vsTeamCode": "HH",
+        "win": 9
+      },
+      {
+        "drawn": 0,
+        "lose": 11,
+        "teamCode": "NC",
+        "teamName": "NC",
+        "vsTeamCode": "HT",
+        "win": 4
+      },
+      {
+        "drawn": 0,
+        "lose": 10,
+        "teamCode": "NC",
+        "teamName": "NC",
+        "vsTeamCode": "KT",
+        "win": 6
+      },
+      {
+        "drawn": 0,
+        "lose": 12,
+        "teamCode": "NC",
+        "teamName": "NC",
+        "vsTeamCode": "LG",
+        "win": 4
+      },
+      {
+        "drawn": 0,
+        "lose": 7,
+        "teamCode": "NC",
+        "teamName": "NC",
+        "vsTeamCode": "LT",
+        "win": 7
+      },
+      {
+        "drawn": 0,
+        "lose": 11,
+        "teamCode": "NC",
+        "teamName": "NC",
+        "vsTeamCode": "OB",
+        "win": 4
+      },
+      {
+        "drawn": 0,
+        "lose": 4,
+        "teamCode": "NC",
+        "teamName": "NC",
+        "vsTeamCode": "SK",
+        "win": 11
+      },
+      {
+        "drawn": 0,
+        "lose": 10,
+        "teamCode": "NC",
+        "teamName": "NC",
+        "vsTeamCode": "SS",
+        "win": 6
+      },
+      {
+        "drawn": 0,
+        "lose": 7,
+        "teamCode": "NC",
+        "teamName": "NC",
+        "vsTeamCode": "WO",
+        "win": 9
+      },
+      {
+        "drawn": 0,
+        "lose": 10,
+        "teamCode": "OB",
+        "teamName": "두산",
+        "vsTeamCode": "HH",
+        "win": 6
+      },
+      {
+        "drawn": 1,
+        "lose": 6,
+        "teamCode": "OB",
+        "teamName": "두산",
+        "vsTeamCode": "HT",
+        "win": 9
+      },
+      {
+        "drawn": 0,
+        "lose": 4,
+        "teamCode": "OB",
+        "teamName": "두산",
+        "vsTeamCode": "KT",
+        "win": 12
+      },
+      {
+        "drawn": 0,
+        "lose": 9,
+        "teamCode": "OB",
+        "teamName": "두산",
+        "vsTeamCode": "LG",
+        "win": 7
+      },
+      {
+        "drawn": 1,
+        "lose": 8,
+        "teamCode": "OB",
+        "teamName": "두산",
+        "vsTeamCode": "LT",
+        "win": 6
+      },
+      {
+        "drawn": 0,
+        "lose": 4,
+        "teamCode": "OB",
+        "teamName": "두산",
+        "vsTeamCode": "NC",
+        "win": 11
+      },
+      {
+        "drawn": 0,
+        "lose": 9,
+        "teamCode": "OB",
+        "teamName": "두산",
+        "vsTeamCode": "SK",
+        "win": 7
+      },
+      {
+        "drawn": 0,
+        "lose": 12,
+        "teamCode": "OB",
+        "teamName": "두산",
+        "vsTeamCode": "SS",
+        "win": 4
+      },
+      {
+        "drawn": 0,
+        "lose": 6,
+        "teamCode": "OB",
+        "teamName": "두산",
+        "vsTeamCode": "WO",
+        "win": 10
+      },
+      {
+        "drawn": 0,
+        "lose": 10,
+        "teamCode": "SK",
+        "teamName": "SSG",
+        "vsTeamCode": "HH",
+        "win": 5
+      },
+      {
+        "drawn": 0,
+        "lose": 6,
+        "teamCode": "SK",
+        "teamName": "SSG",
+        "vsTeamCode": "HT",
+        "win": 10
+      },
+      {
+        "drawn": 0,
+        "lose": 8,
+        "teamCode": "SK",
+        "teamName": "SSG",
+        "vsTeamCode": "KT",
+        "win": 8
+      },
+      {
+        "drawn": 1,
+        "lose": 11,
+        "teamCode": "SK",
+        "teamName": "SSG",
+        "vsTeamCode": "LG",
+        "win": 4
+      },
+      {
+        "drawn": 1,
+        "lose": 6,
+        "teamCode": "SK",
+        "teamName": "SSG",
+        "vsTeamCode": "LT",
+        "win": 9
+      },
+      {
+        "drawn": 0,
+        "lose": 11,
+        "teamCode": "SK",
+        "teamName": "SSG",
+        "vsTeamCode": "NC",
+        "win": 4
+      },
+      {
+        "drawn": 0,
+        "lose": 7,
+        "teamCode": "SK",
+        "teamName": "SSG",
+        "vsTeamCode": "OB",
+        "win": 9
+      },
+      {
+        "drawn": 0,
+        "lose": 7,
+        "teamCode": "SK",
+        "teamName": "SSG",
+        "vsTeamCode": "SS",
+        "win": 9
+      },
+      {
+        "drawn": 0,
+        "lose": 4,
+        "teamCode": "SK",
+        "teamName": "SSG",
+        "vsTeamCode": "WO",
+        "win": 11
+      },
+      {
+        "drawn": 0,
+        "lose": 6,
+        "teamCode": "SS",
+        "teamName": "삼성",
+        "vsTeamCode": "HH",
+        "win": 10
+      },
+      {
+        "drawn": 0,
+        "lose": 12,
+        "teamCode": "SS",
+        "teamName": "삼성",
+        "vsTeamCode": "HT",
+        "win": 4
+      },
+      {
+        "drawn": 1,
+        "lose": 8,
+        "teamCode": "SS",
+        "teamName": "삼성",
+        "vsTeamCode": "KT",
+        "win": 7
+      },
+      {
+        "drawn": 1,
+        "lose": 6,
+        "teamCode": "SS",
+        "teamName": "삼성",
+        "vsTeamCode": "LG",
+        "win": 8
+      },
+      {
+        "drawn": 0,
+        "lose": 6,
+        "teamCode": "SS",
+        "teamName": "삼성",
+        "vsTeamCode": "LT",
+        "win": 10
+      },
+      {
+        "drawn": 0,
+        "lose": 6,
+        "teamCode": "SS",
+        "teamName": "삼성",
+        "vsTeamCode": "NC",
+        "win": 10
+      },
+      {
+        "drawn": 0,
+        "lose": 4,
+        "teamCode": "SS",
+        "teamName": "삼성",
+        "vsTeamCode": "OB",
+        "win": 12
+      },
+      {
+        "drawn": 0,
+        "lose": 9,
+        "teamCode": "SS",
+        "teamName": "삼성",
+        "vsTeamCode": "SK",
+        "win": 7
+      },
+      {
+        "drawn": 0,
+        "lose": 6,
+        "teamCode": "SS",
+        "teamName": "삼성",
+        "vsTeamCode": "WO",
+        "win": 10
+      },
+      {
+        "drawn": 0,
+        "lose": 6,
+        "teamCode": "WO",
+        "teamName": "키움",
+        "vsTeamCode": "HH",
+        "win": 10
+      },
+      {
+        "drawn": 0,
+        "lose": 11,
+        "teamCode": "WO",
+        "teamName": "키움",
+        "vsTeamCode": "HT",
+        "win": 5
+      },
+      {
+        "drawn": 0,
+        "lose": 12,
+        "teamCode": "WO",
+        "teamName": "키움",
+        "vsTeamCode": "KT",
+        "win": 2
+      },
+      {
+        "drawn": 0,
+        "lose": 5,
+        "teamCode": "WO",
+        "teamName": "키움",
+        "vsTeamCode": "LG",
+        "win": 10
+      },
+      {
+        "drawn": 0,
+        "lose": 8,
+        "teamCode": "WO",
+        "teamName": "키움",
+        "vsTeamCode": "LT",
+        "win": 8
+      },
+      {
+        "drawn": 0,
+        "lose": 9,
+        "teamCode": "WO",
+        "teamName": "키움",
+        "vsTeamCode": "NC",
+        "win": 7
+      },
+      {
+        "drawn": 0,
+        "lose": 10,
+        "teamCode": "WO",
+        "teamName": "키움",
+        "vsTeamCode": "OB",
+        "win": 6
+      },
+      {
+        "drawn": 0,
+        "lose": 11,
+        "teamCode": "WO",
+        "teamName": "키움",
+        "vsTeamCode": "SK",
+        "win": 4
+      },
+      {
+        "drawn": 0,
+        "lose": 10,
+        "teamCode": "WO",
+        "teamName": "키움",
+        "vsTeamCode": "SS",
+        "win": 6
       }
     ]
   }

--- a/src/utils/filterData.ts
+++ b/src/utils/filterData.ts
@@ -1,3 +1,5 @@
+import { TTeamVS } from "@customTypes/teamRank";
+
 export const filterData = <T extends Record<string, string | number>>(rawData: T, headers: [string, string][]) => {
   const filteredData = headers.reduce((acc: Record<string, string | number>, curr) => {
     acc[curr[0]] = rawData[curr[0]];
@@ -5,4 +7,9 @@ export const filterData = <T extends Record<string, string | number>>(rawData: T
   }, {});
 
   return filteredData;
+};
+
+export const getVSinfo = (data: TTeamVS[], from: string, to: string) => {
+  const result = data.find((item) => item.teamName === from && item.vsTeamCode === to);
+  return [result?.win, result?.lose, result?.drawn];
 };


### PR DESCRIPTION
## #️⃣ 연관된 이슈

> #89 

## 📝 작업 내용

1. 테이블 api연결
2. 전적 테이블 구현 및 api연결

### 스크린샷 (선택)
![image](https://github.com/user-attachments/assets/4062b2c8-8f77-40ac-a62a-e6d5f3a8d470)


## 💬 리뷰 요구사항(선택)
1. 전적은 기존 테이블과 구조가 달라서 일반 테이블로 구현되었습니다.
2. 나머지 테이블의 스타일링이 빠져있습니다. 이부분은 테이블 로직이 변경되어야 가능할것으로 보여 우선 생략하였습니다.
