### PR TITLE
404에러 재수정

### DIFF
--- a/vercel.json
+++ b/vercel.json
@@ -1,3 +1,3 @@
 {
-  "routes": [{ "handle": "filesystem" }, { "src": "/.*", "dest": "/index.html" }]
+  "routes": [{ "src": "/[^.]+", "dest": "/", "status": 200 }]
 }


### PR DESCRIPTION
이전 설정도 404 에러가 발생하여 추가 수정.
배포가 되어야 확인이 가능하여 추후에 또 수정이 발생할 수 있습니다.