### PR TITLE
fix: 캘린더 스크롤 버그 수정

### DIFF
--- a/src/components/Game/Schedule/Calendar/Cells.tsx
+++ b/src/components/Game/Schedule/Calendar/Cells.tsx
@@ -34,6 +34,10 @@ const CellsStyle = styled.div`
       overflow: hidden;
       gap: 5px;
 
+      &.li {
+        overflow: hidden;
+      }
+
       & > div:first-child {
         position: relative;
         width: 100%;
@@ -101,8 +105,16 @@ const CellsInnerStyle = styled.div`
   display: flex;
   flex-direction: column;
   align-items: center;
-  overflow: scroll;
+  overflow-y: auto;
   gap: 10px;
+
+  &::-webkit-scrollbar {
+    display: none;
+  }
+
+  &.scroll {
+    overflow-y: scroll;
+  }
 
   & > div {
     display: flex;
@@ -212,7 +224,15 @@ const Cells = ({ isKtwizData, currentMonth, setSelectedDate }: CellsProps) => {
                   {wholeDataList
                     .filter((data) => data.displayDate === format(currentDay, "yyyyMMdd"))
                     .map((data, index) => (
-                      <p key={index} className={data.visit.includes("KT") || data.home.includes("KT") ? "red" : ""}>
+                      <p
+                        key={index}
+                        className={
+                          data.visit.includes("KT") || data.home.includes("KT")
+                            ? "red"
+                            : data.visit.length > 6 && data.home.length > 6
+                              ? "scroll"
+                              : ""
+                        }>
                         {`${data.visit}${data.visitScore ? data.visitScore : ""}:${data.home}${data.homeScore ? data.homeScore : ""} [${data.stadium}]`}
                       </p>
                     ))}


### PR DESCRIPTION
## #️⃣ 연관된 이슈

> #147 

## 📝 작업 내용

> - [x] 캘린더 스크롤 버그 수정

### 스크린샷 (선택)
> (개선 전)
> <img width="1121" alt="image" src="https://github.com/user-attachments/assets/4799232d-d164-4318-9c17-6f6b278ad5ed">
> <img width="1122" alt="image" src="https://github.com/user-attachments/assets/e0126c6b-da62-4b96-be5a-66a09fcb394b">
>
> (개선 후)
> <img width="1128" alt="image" src="https://github.com/user-attachments/assets/313cf1b0-6a27-43fe-9dec-f250b1c97947">
> <img width="1133" alt="image" src="https://github.com/user-attachments/assets/4752b2f7-441d-4d50-bea3-6f71307eb39c">

## 💬 리뷰 요구사항(선택)

> 데이터의 길이가 길어졌을 경우에만 스크롤이 작동하고, 스크롤이 작동할 때 스크롤바가 보이지 않도록 숨김처리로 수정하였습니다.