### PR TITLE
순위기록 하위탭 수정

### DIFF
--- a/src/components/common/RankingTab.tsx
+++ b/src/components/common/RankingTab.tsx
@@ -14,9 +14,7 @@ const TabItem = styled.li`
   height: 40px;
   box-sizing: border-box;
   border: 1px solid #e4e4e4;
-  &:active {
-    background-color: red;
-  }
+
   &:not(:first-child) {
     border-left: none;
   }
@@ -37,13 +35,7 @@ const RankingTab = () => {
   return (
     <Tab>
       <TabItem>
-        <TabTitle to="">팀순위</TabTitle>
-      </TabItem>
-      <TabItem>
-        <TabTitle to="../pitcher">투수순위</TabTitle>
-      </TabItem>
-      <TabItem>
-        <TabTitle to="../batter">타자순위</TabTitle>
+        <TabTitle to="../team">팀순위</TabTitle>
       </TabItem>
       <TabItem>
         <TabTitle to="../crowd">관중현황</TabTitle>

--- a/src/pages/Audience.tsx
+++ b/src/pages/Audience.tsx
@@ -1,4 +1,5 @@
 import AudieunceRecord from "@components/Audience/AudienceRecord";
+import RankingTab from "@components/common/RankingTab.tsx";
 import styled from "styled-components";
 import AccrueAudience from "../components/Audience/AccrueAudience.tsx";
 
@@ -9,6 +10,7 @@ const AudienceWrapper = styled.div`
 const Audience = () => {
   return (
     <AudienceWrapper>
+      <RankingTab />
       <AccrueAudience />
       <AudieunceRecord />
     </AudienceWrapper>


### PR DESCRIPTION
## #️⃣ 연관된 이슈

> #149

## 📝 작업 내용

1. 관중현황 페이지에 하위탭 추가
2. 구현되지 않은 탭 삭제

### 스크린샷 (선택)
![image](https://github.com/user-attachments/assets/9a169c51-40b5-4d50-abe4-1c97629ed809)


## 💬 리뷰 요구사항(선택)

